### PR TITLE
feat: add v0.2.0 Ghaghara portfolio discovery

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -1,0 +1,26 @@
+name: Portfolio scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Discover UN/CEFACT projects
+        run: python scripts/discover_portfolio.py
+      - name: Upload portfolio snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: uncefact-portfolio-snapshot
+          path: reports/latest/portfolio.json
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ Evidence-driven monitoring of the UN/CEFACT open-source portfolio: repository he
 4. **Provider neutrality.** CI, repository inspection, specification checks, RAHP, and future analyzers may contribute evidence; none is the universal source of truth.
 5. **Human review for material inference.** The monitor identifies review obligations; it does not silently convert change into trust conclusions.
 
+## Current capability
+
+`v0.2.x` adds dynamic discovery of the public UN/CEFACT GitLab portfolio under `un/unece/uncefact`.
+
+Run locally:
+
+```bash
+python scripts/discover_portfolio.py
+```
+
+The collector:
+
+- reads the namespace from `config/portfolio.toml`;
+- follows GitLab pagination;
+- includes subgroups;
+- normalizes evidence-relevant project metadata;
+- writes stable JSON to `reports/latest/portfolio.json`.
+
+GitHub Actions also runs the scan weekly and on demand, retaining the resulting snapshot as an artifact for later inspection and comparison.
+
 ## Development flow
 
 Substantive work follows:
@@ -22,8 +42,9 @@ The repository's first README commit was the only bootstrap exception required t
 
 Each release receives a randomly selected codename from the direct pages in Wikipedia's `Category:Tributaries of the Ganges`. The selected name is recorded in the release manifest, making the outcome auditable even though selection is random.
 
-Current foundation release: **v0.1.0 — Tamsa**.
+- **v0.1.0 — Tamsa**: foundation, governance, CI, and release automation.
+- **v0.2.0 — Ghaghara**: dynamic GitLab portfolio discovery and scan artifacts.
 
-## Status
+## Roadmap
 
-Early development. The first milestone establishes governance and release automation; portfolio discovery follows in v0.2.x.
+Next milestones add change detection, repository-health evidence, explicit cross-project relationships, impact propagation, and portfolio findings. The monitor will remain evidence-driven and will not treat any single assurance provider as the portfolio-wide source of truth.

--- a/config/portfolio.toml
+++ b/config/portfolio.toml
@@ -1,0 +1,10 @@
+[source]
+provider = "gitlab"
+base_url = "https://opensource.unicc.org"
+group = "un/unece/uncefact"
+include_subgroups = true
+archived = false
+visibility = "public"
+
+[output]
+path = "reports/latest/portfolio.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.1.0"
+version = "0.2.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.2.0.yaml
+++ b/releases/v0.2.0.yaml
@@ -1,0 +1,5 @@
+version: v0.2.0
+codename: Ghaghara
+status: release
+summary: Dynamic UN/CEFACT GitLab portfolio discovery with normalized snapshots and scheduled scan artifacts.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/discover_portfolio.py
+++ b/scripts/discover_portfolio.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.gitlab import GitLabSource, build_snapshot, discover_projects
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Discover the configured UN/CEFACT GitLab portfolio")
+    parser.add_argument("--config", type=Path, default=ROOT / "config" / "portfolio.toml")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    config = tomllib.loads(args.config.read_text(encoding="utf-8"))
+    source_config = config["source"]
+    source = GitLabSource(
+        base_url=source_config["base_url"],
+        group=source_config["group"],
+        include_subgroups=source_config.get("include_subgroups", True),
+        archived=source_config.get("archived", False),
+    )
+    projects = discover_projects(source)
+    snapshot = build_snapshot(source, projects)
+    output = args.output or ROOT / config["output"]["path"]
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"discovered {len(projects)} projects -> {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/__init__.py
+++ b/src/uncefact_portfolio_monitor/__init__.py
@@ -1,0 +1,3 @@
+"""UN/CEFACT Portfolio Monitor."""
+
+__version__ = "0.2.0"

--- a/src/uncefact_portfolio_monitor/gitlab.py
+++ b/src/uncefact_portfolio_monitor/gitlab.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class GitLabSource:
+    base_url: str
+    group: str
+    include_subgroups: bool = True
+    archived: bool = False
+
+
+def _request_json(url: str) -> tuple[list[dict[str, Any]], str]:
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": "uncefact-portfolio-monitor"})
+    with urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+        next_page = response.headers.get("X-Next-Page", "")
+    if not isinstance(payload, list):
+        raise ValueError("GitLab projects endpoint did not return a list")
+    return payload, next_page
+
+
+def normalize_project(project: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": project.get("id"),
+        "name": project.get("name"),
+        "path_with_namespace": project.get("path_with_namespace"),
+        "web_url": project.get("web_url"),
+        "default_branch": project.get("default_branch"),
+        "visibility": project.get("visibility"),
+        "archived": bool(project.get("archived", False)),
+        "last_activity_at": project.get("last_activity_at"),
+        "description": project.get("description"),
+        "topics": sorted(project.get("topics") or []),
+    }
+
+
+def discover_projects(source: GitLabSource, requester=_request_json) -> list[dict[str, Any]]:
+    page = "1"
+    projects: list[dict[str, Any]] = []
+    encoded_group = quote(source.group, safe="")
+    while page:
+        query = urlencode({
+            "include_subgroups": str(source.include_subgroups).lower(),
+            "archived": str(source.archived).lower(),
+            "simple": "true",
+            "per_page": "100",
+            "page": page,
+        })
+        url = f"{source.base_url.rstrip('/')}/api/v4/groups/{encoded_group}/projects?{query}"
+        payload, page = requester(url)
+        projects.extend(normalize_project(item) for item in payload)
+    return sorted(projects, key=lambda item: (item.get("path_with_namespace") or ""))
+
+
+def build_snapshot(source: GitLabSource, projects: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "provider": "gitlab",
+            "base_url": source.base_url,
+            "group": source.group,
+            "include_subgroups": source.include_subgroups,
+            "archived": source.archived,
+        },
+        "project_count": len(projects),
+        "projects": projects,
+    }

--- a/tests/test_gitlab_discovery.py
+++ b/tests/test_gitlab_discovery.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import unittest
+from urllib.parse import parse_qs, urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
@@ -25,7 +26,8 @@ class GitLabDiscoveryTests(unittest.TestCase):
 
         def requester(url):
             calls.append(url)
-            if "page=1" in url:
+            page = parse_qs(urlparse(url).query)["page"][0]
+            if page == "1":
                 return ([{"id": 2, "name": "B", "path_with_namespace": "un/unece/uncefact/b"}], "2")
             return ([{"id": 1, "name": "A", "path_with_namespace": "un/unece/uncefact/a"}], "")
 

--- a/tests/test_gitlab_discovery.py
+++ b/tests/test_gitlab_discovery.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.gitlab import GitLabSource, discover_projects, normalize_project
+
+
+class GitLabDiscoveryTests(unittest.TestCase):
+    def test_normalization_is_stable(self):
+        project = normalize_project({
+            "id": 2,
+            "name": "B",
+            "path_with_namespace": "un/unece/uncefact/b",
+            "topics": ["z", "a"],
+            "archived": False,
+        })
+        self.assertEqual(project["topics"], ["a", "z"])
+        self.assertFalse(project["archived"])
+
+    def test_pagination_and_sorting(self):
+        calls = []
+
+        def requester(url):
+            calls.append(url)
+            if "page=1" in url:
+                return ([{"id": 2, "name": "B", "path_with_namespace": "un/unece/uncefact/b"}], "2")
+            return ([{"id": 1, "name": "A", "path_with_namespace": "un/unece/uncefact/a"}], "")
+
+        projects = discover_projects(
+            GitLabSource("https://example.test", "un/unece/uncefact"),
+            requester=requester,
+        )
+        self.assertEqual([item["id"] for item in projects], [1, 2])
+        self.assertEqual(len(calls), 2)
+        self.assertIn("un%2Funece%2Funcefact", calls[0])
+        self.assertIn("include_subgroups=true", calls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3.

## What this adds
- declarative UN/CEFACT GitLab namespace configuration
- dependency-free paginated GitLab project discovery
- stable normalized JSON snapshot format
- local discovery CLI
- deterministic unit coverage for normalization and pagination
- weekly/manual GitHub Actions portfolio scan
- 30-day scan artifact retention
- `v0.2.0 — Ghaghara` release manifest

## Deliberate boundary
This release discovers and records the portfolio only. It does not yet infer change impact, relationships, health scores, or assurance findings; those remain separately reviewable milestones.

On merge, the release manifest will trigger the existing Actions release workflow and publish `v0.2.0 — Ghaghara`.