### PR TITLE
feat: publish v0.3.0 Varuna portfolio page

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -1,15 +1,23 @@
-name: Portfolio scan
+name: Portfolio scan and Pages
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '17 3 * * 1'
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  discover:
+  discover-and-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,9 +26,30 @@ jobs:
           python-version: '3.11'
       - name: Discover UN/CEFACT projects
         run: python scripts/discover_portfolio.py
+      - name: Build portfolio site
+        run: python scripts/build_site.py
       - name: Upload portfolio snapshot
         uses: actions/upload-artifact@v4
         with:
           name: uncefact-portfolio-snapshot
           path: reports/latest/portfolio.json
           retention-days: 30
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: discover-and-build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.2.0"
+version = "0.3.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.3.0.yaml
+++ b/releases/v0.3.0.yaml
@@ -1,0 +1,5 @@
+version: v0.3.0
+codename: Varuna
+status: release
+summary: Live UN/CEFACT portfolio discovery published as an evidence-linked GitHub Pages view.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from html import escape
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fmt_date(value: str | None) -> str:
+    if not value:
+        return "Unknown"
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return value
+
+
+def render(snapshot: dict) -> str:
+    projects = snapshot.get("projects", [])
+    generated_at = snapshot.get("generated_at", "unknown")
+    source = snapshot.get("source", {})
+    rows = []
+    for project in projects:
+        topics = ", ".join(project.get("topics") or [])
+        search_blob = " ".join([
+            project.get("name") or "",
+            project.get("path_with_namespace") or "",
+            project.get("description") or "",
+            topics,
+        ]).lower()
+        state = "Archived" if project.get("archived") else "Active"
+        rows.append(f'''<tr data-search="{escape(search_blob, quote=True)}" data-state="{state.lower()}">
+<td><a href="{escape(project.get('web_url') or '#', quote=True)}">{escape(project.get('name') or 'Unnamed')}</a><div class="path">{escape(project.get('path_with_namespace') or '')}</div></td>
+<td>{escape(project.get('default_branch') or '—')}</td>
+<td>{state}</td>
+<td>{escape(fmt_date(project.get('last_activity_at')))}</td>
+<td>{escape(topics or '—')}</td>
+</tr>''')
+
+    return f'''<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Monitor</title>
+<style>
+:root{{color-scheme:light dark;--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}
+@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff}}}}
+*{{box-sizing:border-box}} body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}} a{{color:var(--accent);text-decoration:none}} a:hover{{text-decoration:underline}}
+main{{max-width:1240px;margin:auto;padding:40px 24px 72px}} h1{{font-size:34px;margin:0 0 8px}} .lede{{color:var(--muted);max-width:800px;margin:0 0 28px}}
+.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:24px 0}} .stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px}} .stat strong{{display:block;font-size:25px}}
+.controls{{display:flex;gap:10px;flex-wrap:wrap;margin:24px 0}} input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}} input{{min-width:min(100%,360px);flex:1}}
+.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}} table{{width:100%;border-collapse:collapse;min-width:900px}} th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}} th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}} tr:last-child td{{border-bottom:0}} .path{{font-size:12px;color:var(--muted);margin-top:3px}} footer{{color:var(--muted);font-size:13px;margin-top:28px}} code{{font-size:12px}} .note{{border-left:3px solid var(--accent);padding:10px 14px;background:var(--panel);margin:24px 0}}
+</style>
+</head>
+<body><main>
+<h1>UN/CEFACT Portfolio Monitor</h1>
+<p class="lede">Live discovery of public projects in the UN/CEFACT GitLab namespace. This page reports observable repository metadata only; it does not yet assign health, impact, or assurance conclusions.</p>
+<div class="stats">
+<div class="stat"><span>Discovered projects</span><strong>{len(projects)}</strong></div>
+<div class="stat"><span>Source</span><strong>GitLab</strong><small>{escape(source.get('group',''))}</small></div>
+<div class="stat"><span>Observed</span><strong>{escape(fmt_date(generated_at))}</strong><small>UTC snapshot</small></div>
+</div>
+<div class="note">The exact normalized evidence used to generate this view is available as <a href="portfolio.json">portfolio.json</a>.</div>
+<div class="controls"><input id="q" type="search" placeholder="Search projects, paths, descriptions or topics…" aria-label="Search portfolio"><select id="state"><option value="all">All states</option><option value="active">Active</option><option value="archived">Archived</option></select></div>
+<div class="table-wrap"><table><thead><tr><th>Project</th><th>Default branch</th><th>State</th><th>Last activity</th><th>Topics</th></tr></thead><tbody id="rows">{''.join(rows)}</tbody></table></div>
+<footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Portfolio inventory is observational evidence, not an assurance score.</footer>
+</main>
+<script>
+const q=document.getElementById('q'), state=document.getElementById('state');
+function filter(){{const text=q.value.trim().toLowerCase(), s=state.value;document.querySelectorAll('#rows tr').forEach(row=>{{const matchesText=!text||row.dataset.search.includes(text);const matchesState=s==='all'||row.dataset.state===s;row.hidden=!(matchesText&&matchesState);}})}}
+q.addEventListener('input',filter);state.addEventListener('change',filter);
+</script></body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the static portfolio site from a normalized snapshot")
+    parser.add_argument("--input", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+    snapshot = json.loads(args.input.read_text(encoding="utf-8"))
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "index.html").write_text(render(snapshot), encoding="utf-8")
+    (args.output_dir / "portfolio.json").write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"built site with {snapshot.get('project_count', len(snapshot.get('projects', [])))} projects -> {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("build_site", ROOT / "scripts" / "build_site.py")
+build_site = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(build_site)
+
+
+class SiteTests(unittest.TestCase):
+    def test_render_uses_snapshot_projects_and_evidence_link(self):
+        snapshot = {
+            "generated_at": "2026-08-25T05:00:00Z",
+            "source": {"base_url": "https://opensource.unicc.org", "group": "un/unece/uncefact"},
+            "projects": [{
+                "name": "Example",
+                "path_with_namespace": "un/unece/uncefact/example",
+                "web_url": "https://opensource.unicc.org/un/unece/uncefact/example",
+                "default_branch": "main",
+                "archived": False,
+                "last_activity_at": "2026-08-24T12:00:00Z",
+                "topics": ["trade"],
+                "description": "Example project",
+            }],
+        }
+        html = build_site.render(snapshot)
+        self.assertIn("Example", html)
+        self.assertIn("un/unece/uncefact/example", html)
+        self.assertIn("portfolio.json", html)
+        self.assertIn("observational evidence", html.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #5.

## What this adds
- static GitHub Pages portfolio view generated from discovery evidence
- exact `portfolio.json` snapshot published beside the page
- search and active/archived filtering without external JS dependencies
- observable project metadata: path, default branch, state, last activity, topics, and source links
- live GitLab discovery during each deployment
- deployment on `main` pushes, weekly schedule, and manual dispatch
- retained raw snapshot artifact
- page-generation unit coverage
- `v0.3.0 — Varuna` release manifest

## Assurance boundary
The page is explicitly observational. It does not yet turn project inventory/activity into repository health, impact, or assurance conclusions.

On merge, the portfolio workflow will discover the live UN/CEFACT namespace, build and publish the page, while the release workflow publishes `v0.3.0 — Varuna`.