### PR TITLE
feat: add v0.4.0 Kosi portfolio change detection

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -24,15 +24,35 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Restore previous portfolio baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: .state/portfolio.json
+          key: portfolio-baseline-${{ github.run_id }}
+          restore-keys: |
+            portfolio-baseline-
       - name: Discover UN/CEFACT projects
         run: python scripts/discover_portfolio.py
+      - name: Compare with previous observation
+        run: python scripts/compare_snapshots.py
       - name: Build portfolio site
         run: python scripts/build_site.py
-      - name: Upload portfolio snapshot
+      - name: Advance baseline
+        run: |
+          mkdir -p .state
+          cp reports/latest/portfolio.json .state/portfolio.json
+      - name: Save current portfolio baseline
+        uses: actions/cache/save@v4
+        with:
+          path: .state/portfolio.json
+          key: portfolio-baseline-${{ github.run_id }}
+      - name: Upload portfolio evidence
         uses: actions/upload-artifact@v4
         with:
-          name: uncefact-portfolio-snapshot
-          path: reports/latest/portfolio.json
+          name: uncefact-portfolio-evidence
+          path: |
+            reports/latest/portfolio.json
+            reports/latest/changes.json
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/docs/change-model.md
+++ b/docs/change-model.md
@@ -1,0 +1,19 @@
+# Portfolio change model
+
+The monitor compares normalized GitLab observations by stable project ID.
+
+## Structural change
+
+The following fields are treated as structural metadata: project path, default branch, visibility, archived state, description, and topics. A change record preserves before/after values.
+
+## Activity advancement
+
+`last_activity_at` movement is recorded separately. Activity is evidence that a repository changed, but it is not by itself a structural change or assurance finding.
+
+## First observation
+
+When no previous baseline is available, the current portfolio establishes the baseline. Projects are **not** reported as newly added merely because the monitor has seen them for the first time.
+
+## Assurance boundary
+
+Change data is observational evidence only. Relationship-aware review obligations and assurance findings are separate downstream layers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.3.0"
+version = "0.4.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.4.0.yaml
+++ b/releases/v0.4.0.yaml
@@ -1,0 +1,5 @@
+version: v0.4.0
+codename: Kosi
+status: release
+summary: Historical portfolio baseline comparison with machine-readable change evidence and Pages change reporting.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -20,7 +20,7 @@ def fmt_date(value: str | None) -> str:
         return value
 
 
-def render(snapshot: dict) -> str:
+def render(snapshot: dict, changes: dict | None = None) -> str:
     projects = snapshot.get("projects", [])
     generated_at = snapshot.get("generated_at", "unknown")
     source = snapshot.get("source", {})
@@ -42,6 +42,15 @@ def render(snapshot: dict) -> str:
 <td>{escape(topics or '—')}</td>
 </tr>''')
 
+    change_html = ""
+    change_stat = ""
+    if changes:
+        summary = changes.get("summary", {})
+        total_structural = int(summary.get("added", 0)) + int(summary.get("removed", 0)) + int(summary.get("changed", 0))
+        baseline = changes.get("baseline", "unknown")
+        change_stat = f'''<div class="stat"><span>Structural changes</span><strong>{total_structural}</strong><small>Since previous observation</small></div>'''
+        change_html = f'''<div class="note"><strong>Latest observed change:</strong> {summary.get('added',0)} added, {summary.get('removed',0)} removed, {summary.get('changed',0)} metadata-changed, {summary.get('activity_advanced',0)} with activity advancement. Baseline: {escape(str(baseline))}. <a href="changes.json">Inspect changes.json</a>.</div>'''
+
     return f'''<!doctype html>
 <html lang="en">
 <head>
@@ -53,23 +62,25 @@ def render(snapshot: dict) -> str:
 @media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff}}}}
 *{{box-sizing:border-box}} body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}} a{{color:var(--accent);text-decoration:none}} a:hover{{text-decoration:underline}}
 main{{max-width:1240px;margin:auto;padding:40px 24px 72px}} h1{{font-size:34px;margin:0 0 8px}} .lede{{color:var(--muted);max-width:800px;margin:0 0 28px}}
-.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:24px 0}} .stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px}} .stat strong{{display:block;font-size:25px}}
+.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:24px 0}} .stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px}} .stat strong{{display:block;font-size:25px}} .stat small{{display:block;color:var(--muted);margin-top:3px}}
 .controls{{display:flex;gap:10px;flex-wrap:wrap;margin:24px 0}} input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}} input{{min-width:min(100%,360px);flex:1}}
 .table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}} table{{width:100%;border-collapse:collapse;min-width:900px}} th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}} th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}} tr:last-child td{{border-bottom:0}} .path{{font-size:12px;color:var(--muted);margin-top:3px}} footer{{color:var(--muted);font-size:13px;margin-top:28px}} code{{font-size:12px}} .note{{border-left:3px solid var(--accent);padding:10px 14px;background:var(--panel);margin:24px 0}}
 </style>
 </head>
 <body><main>
 <h1>UN/CEFACT Portfolio Monitor</h1>
-<p class="lede">Live discovery of public projects in the UN/CEFACT GitLab namespace. This page reports observable repository metadata only; it does not yet assign health, impact, or assurance conclusions.</p>
+<p class="lede">Live discovery of public projects in the UN/CEFACT GitLab namespace. This page reports observable repository metadata and changes only; it does not assign health, impact, or assurance conclusions.</p>
 <div class="stats">
 <div class="stat"><span>Discovered projects</span><strong>{len(projects)}</strong></div>
 <div class="stat"><span>Source</span><strong>GitLab</strong><small>{escape(source.get('group',''))}</small></div>
 <div class="stat"><span>Observed</span><strong>{escape(fmt_date(generated_at))}</strong><small>UTC snapshot</small></div>
+{change_stat}
 </div>
 <div class="note">The exact normalized evidence used to generate this view is available as <a href="portfolio.json">portfolio.json</a>.</div>
+{change_html}
 <div class="controls"><input id="q" type="search" placeholder="Search projects, paths, descriptions or topics…" aria-label="Search portfolio"><select id="state"><option value="all">All states</option><option value="active">Active</option><option value="archived">Archived</option></select></div>
 <div class="table-wrap"><table><thead><tr><th>Project</th><th>Default branch</th><th>State</th><th>Last activity</th><th>Topics</th></tr></thead><tbody id="rows">{''.join(rows)}</tbody></table></div>
-<footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Portfolio inventory is observational evidence, not an assurance score.</footer>
+<footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Portfolio inventory and change data are observational evidence, not assurance scores.</footer>
 </main>
 <script>
 const q=document.getElementById('q'), state=document.getElementById('state');
@@ -79,14 +90,18 @@ q.addEventListener('input',filter);state.addEventListener('change',filter);
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Build the static portfolio site from a normalized snapshot")
+    parser = argparse.ArgumentParser(description="Build the static portfolio site from normalized evidence")
     parser.add_argument("--input", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--changes", type=Path, default=ROOT / "reports" / "latest" / "changes.json")
     parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
     args = parser.parse_args()
     snapshot = json.loads(args.input.read_text(encoding="utf-8"))
+    changes = json.loads(args.changes.read_text(encoding="utf-8")) if args.changes.exists() else None
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    (args.output_dir / "index.html").write_text(render(snapshot), encoding="utf-8")
+    (args.output_dir / "index.html").write_text(render(snapshot, changes), encoding="utf-8")
     (args.output_dir / "portfolio.json").write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if changes:
+        (args.output_dir / "changes.json").write_text(json.dumps(changes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(f"built site with {snapshot.get('project_count', len(snapshot.get('projects', [])))} projects -> {args.output_dir}")
     return 0
 

--- a/scripts/compare_snapshots.py
+++ b/scripts/compare_snapshots.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.changes import compare_snapshots
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare UN/CEFACT portfolio snapshots")
+    parser.add_argument("--previous", type=Path, default=ROOT / ".state" / "portfolio.json")
+    parser.add_argument("--current", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--output", type=Path, default=ROOT / "reports" / "latest" / "changes.json")
+    args = parser.parse_args()
+
+    previous = None
+    if args.previous.exists():
+        previous = json.loads(args.previous.read_text(encoding="utf-8"))
+    current = json.loads(args.current.read_text(encoding="utf-8"))
+    result = compare_snapshots(previous, current)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary = result["summary"]
+    print(
+        "changes: "
+        f"added={summary['added']} removed={summary['removed']} "
+        f"changed={summary['changed']} activity={summary['activity_advanced']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/changes.py
+++ b/src/uncefact_portfolio_monitor/changes.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+
+STRUCTURAL_FIELDS = (
+    "path_with_namespace",
+    "default_branch",
+    "visibility",
+    "archived",
+    "description",
+    "topics",
+)
+
+
+def _index(snapshot: dict[str, Any]) -> dict[Any, dict[str, Any]]:
+    return {project.get("id"): project for project in snapshot.get("projects", []) if project.get("id") is not None}
+
+
+def compare_snapshots(previous: dict[str, Any] | None, current: dict[str, Any]) -> dict[str, Any]:
+    if not previous:
+        return {
+            "schema_version": "1",
+            "baseline": "none",
+            "previous_generated_at": None,
+            "current_generated_at": current.get("generated_at"),
+            "summary": {"added": 0, "removed": 0, "changed": 0, "activity_advanced": 0},
+            "added": [],
+            "removed": [],
+            "changed": [],
+            "activity_advanced": [],
+        }
+
+    before = _index(previous)
+    after = _index(current)
+    added_ids = sorted(set(after) - set(before))
+    removed_ids = sorted(set(before) - set(after))
+    shared_ids = sorted(set(before) & set(after))
+
+    added = [after[project_id] for project_id in added_ids]
+    removed = [before[project_id] for project_id in removed_ids]
+    changed: list[dict[str, Any]] = []
+    activity_advanced: list[dict[str, Any]] = []
+
+    for project_id in shared_ids:
+        old = before[project_id]
+        new = after[project_id]
+        fields: dict[str, dict[str, Any]] = {}
+        for field in STRUCTURAL_FIELDS:
+            if old.get(field) != new.get(field):
+                fields[field] = {"before": old.get(field), "after": new.get(field)}
+        if fields:
+            changed.append({
+                "id": project_id,
+                "path_with_namespace": new.get("path_with_namespace") or old.get("path_with_namespace"),
+                "fields": fields,
+            })
+        if old.get("last_activity_at") != new.get("last_activity_at"):
+            activity_advanced.append({
+                "id": project_id,
+                "path_with_namespace": new.get("path_with_namespace") or old.get("path_with_namespace"),
+                "before": old.get("last_activity_at"),
+                "after": new.get("last_activity_at"),
+            })
+
+    return {
+        "schema_version": "1",
+        "baseline": "previous-snapshot",
+        "previous_generated_at": previous.get("generated_at"),
+        "current_generated_at": current.get("generated_at"),
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+            "activity_advanced": len(activity_advanced),
+        },
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "activity_advanced": activity_advanced,
+    }

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.changes import compare_snapshots
+
+
+def snapshot(projects, generated_at="2026-08-25T00:00:00Z"):
+    return {"generated_at": generated_at, "projects": projects}
+
+
+class ChangeDetectionTests(unittest.TestCase):
+    def test_first_run_is_explicit_baseline(self):
+        current = snapshot([{"id": 1, "path_with_namespace": "a"}])
+        result = compare_snapshots(None, current)
+        self.assertEqual(result["baseline"], "none")
+        self.assertEqual(result["summary"], {"added": 0, "removed": 0, "changed": 0, "activity_advanced": 0})
+
+    def test_added_removed_structural_and_activity_are_separate(self):
+        previous = snapshot([
+            {"id": 1, "path_with_namespace": "a", "default_branch": "main", "archived": False, "topics": [], "last_activity_at": "2026-08-20T00:00:00Z"},
+            {"id": 2, "path_with_namespace": "b", "default_branch": "main", "archived": False, "topics": [], "last_activity_at": "2026-08-20T00:00:00Z"},
+        ])
+        current = snapshot([
+            {"id": 1, "path_with_namespace": "a", "default_branch": "trunk", "archived": False, "topics": [], "last_activity_at": "2026-08-25T00:00:00Z"},
+            {"id": 3, "path_with_namespace": "c", "default_branch": "main", "archived": False, "topics": [], "last_activity_at": "2026-08-25T00:00:00Z"},
+        ], "2026-08-26T00:00:00Z")
+        result = compare_snapshots(previous, current)
+        self.assertEqual(result["summary"], {"added": 1, "removed": 1, "changed": 1, "activity_advanced": 1})
+        self.assertEqual(result["changed"][0]["fields"]["default_branch"], {"before": "main", "after": "trunk"})
+        self.assertEqual(result["activity_advanced"][0]["id"], 1)
+
+    def test_activity_only_is_not_structural_change(self):
+        previous = snapshot([{"id": 1, "path_with_namespace": "a", "last_activity_at": "old"}])
+        current = snapshot([{"id": 1, "path_with_namespace": "a", "last_activity_at": "new"}])
+        result = compare_snapshots(previous, current)
+        self.assertEqual(result["summary"]["changed"], 0)
+        self.assertEqual(result["summary"]["activity_advanced"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #7.

## What this adds
- deterministic comparison of normalized portfolio snapshots by stable GitLab project ID
- explicit first-observation baseline semantics
- added/removed project detection
- structural metadata change detection with before/after evidence
- activity timestamp advancement recorded separately from structural change
- machine-readable `changes.json`
- persisted prior baseline via Actions cache without generated-data commits to `main`
- Pages summary of latest observed portfolio changes
- retained portfolio + change evidence artifact
- unit coverage for baseline, structural change, and activity-only behavior
- `v0.4.0 — Kosi` release manifest

## Assurance boundary
Observed change remains evidence only. This release does not infer cross-project impact or assurance findings.

On merge, Actions will establish/advance the live baseline, republish Pages, and publish `v0.4.0 — Kosi`.