### PR TITLE
feat: add v0.5.0 Ramganga portfolio relationship graph

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -37,6 +37,8 @@ jobs:
         run: python scripts/compare_snapshots.py
       - name: Build portfolio site
         run: python scripts/build_site.py
+      - name: Validate and publish relationships
+        run: python scripts/build_relationships.py
       - name: Advance baseline
         run: |
           mkdir -p .state
@@ -53,6 +55,8 @@ jobs:
           path: |
             reports/latest/portfolio.json
             reports/latest/changes.json
+            site/relationships.json
+            site/relationships.mmd
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/config/relationships.toml
+++ b/config/relationships.toml
@@ -1,0 +1,31 @@
+schema_version = "1"
+
+[[relationships]]
+from = "un/unece/uncefact/spec-unttp"
+to = "un/unece/uncefact/spec-untp"
+type = "profile-of"
+note = "UNTP Textiles is an industry extension of core UNTP."
+
+[[relationships]]
+from = "un/unece/uncefact/spec-uncrmtp"
+to = "un/unece/uncefact/spec-untp"
+type = "profile-of"
+note = "Critical Raw Materials/CETM is an extension of core UNTP."
+
+[[relationships]]
+from = "un/unece/uncefact/untp-agrifood"
+to = "un/unece/uncefact/spec-untp"
+type = "profile-of"
+note = "UNTP Agrifood is an industry extension of core UNTP."
+
+[[relationships]]
+from = "un/unece/uncefact/spec-untp"
+to = "un/unece/uncefact/gtr"
+type = "trust-infrastructure-dependency"
+note = "UNTP Digital Identity Anchor work is coordinated with GRID/GTR trust infrastructure."
+
+[[relationships]]
+from = "un/unece/uncefact/spec-unvtd"
+to = "un/unece/uncefact/gtr"
+type = "related-to"
+note = "UN Verifiable Trade Documents references trust registry integration while remaining architecturally independent."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.4.0"
+version = "0.5.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.5.0.yaml
+++ b/releases/v0.5.0.yaml
@@ -1,0 +1,5 @@
+version: v0.5.0
+codename: Ramganga
+status: release
+summary: Explicit validated and provenance-aware UN/CEFACT portfolio relationship graph published as machine-readable evidence and Pages views.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_relationships.py
+++ b/scripts/build_relationships.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from html import escape
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.relationships import mermaid_graph, validate_relationships
+
+
+def render(data: dict, mermaid: str) -> str:
+    rows = []
+    for rel in data.get("relationships", []):
+        rows.append(
+            "<tr>"
+            f"<td><code>{escape(rel['from'])}</code></td>"
+            f"<td>{escape(rel['type'])}</td>"
+            f"<td><code>{escape(rel['to'])}</code></td>"
+            f"<td>{escape(rel.get('note') or '—')}</td>"
+            "</tr>"
+        )
+    return f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Relationships</title>
+<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code,pre{{font-family:ui-monospace,SFMono-Regular,monospace}}pre{{overflow:auto;background:#f5f7fa;padding:16px;border-radius:8px}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
+<body><p><a href="index.html">← Portfolio</a></p><h1>Declared portfolio relationships</h1>
+<p>This view publishes manually reviewed relationship declarations over the discovered portfolio. These declarations are governance inputs, not facts inferred from repository activity and not statements of trust or authority.</p>
+<div class="note">Machine-readable evidence: <a href="relationships.json">relationships.json</a> · Mermaid source: <a href="relationships.mmd">relationships.mmd</a></div>
+<table><thead><tr><th>From</th><th>Relationship</th><th>To</th><th>Note</th></tr></thead><tbody>{''.join(rows)}</tbody></table>
+<h2>Mermaid graph source</h2><pre>{escape(mermaid)}</pre>
+</body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate and publish declared portfolio relationships")
+    parser.add_argument("--snapshot", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--config", type=Path, default=ROOT / "config" / "relationships.toml")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+
+    snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    config = tomllib.loads(args.config.read_text(encoding="utf-8"))
+    data = validate_relationships(snapshot, config)
+    mermaid = mermaid_graph(data)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "relationships.json").write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "relationships.mmd").write_text(mermaid, encoding="utf-8")
+    (args.output_dir / "relationships.html").write_text(render(data, mermaid), encoding="utf-8")
+    print(f"validated and published {data['relationship_count']} relationships")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/relationships.py
+++ b/src/uncefact_portfolio_monitor/relationships.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+ALLOWED_TYPES = {
+    "depends-on",
+    "profile-of",
+    "semantic-dependency",
+    "trust-infrastructure-dependency",
+    "related-to",
+}
+
+
+def validate_relationships(snapshot: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    projects = {item.get("path_with_namespace") for item in snapshot.get("projects", [])}
+    relationships = config.get("relationships", [])
+    normalized: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for index, rel in enumerate(relationships, start=1):
+        source = rel.get("from")
+        target = rel.get("to")
+        kind = rel.get("type")
+        if kind not in ALLOWED_TYPES:
+            errors.append(f"relationship {index}: unsupported type {kind!r}")
+        if source not in projects:
+            errors.append(f"relationship {index}: unknown internal source {source!r}")
+        if target not in projects:
+            errors.append(f"relationship {index}: unknown internal target {target!r}")
+        normalized.append({
+            "from": source,
+            "to": target,
+            "type": kind,
+            "note": rel.get("note", ""),
+            "provenance": "declared",
+        })
+
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    return {
+        "schema_version": str(config.get("schema_version", "1")),
+        "generated_from": snapshot.get("generated_at"),
+        "provenance": "declared-portfolio-configuration",
+        "relationship_count": len(normalized),
+        "relationships": normalized,
+    }
+
+
+def mermaid_graph(data: dict[str, Any]) -> str:
+    nodes: dict[str, str] = {}
+    lines = ["graph LR"]
+    for rel in data.get("relationships", []):
+        for path in (rel["from"], rel["to"]):
+            if path not in nodes:
+                node_id = f"n{len(nodes) + 1}"
+                nodes[path] = node_id
+                lines.append(f'    {node_id}["{path.split("/")[-1]}"]')
+        label = rel["type"].replace("-", " ")
+        lines.append(f'    {nodes[rel["from"]]} -->|"{label}"| {nodes[rel["to"]]}')
+    return "\n".join(lines) + "\n"

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.relationships import mermaid_graph, validate_relationships
+
+
+class RelationshipTests(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = {
+            "generated_at": "2026-08-25T00:00:00Z",
+            "projects": [
+                {"path_with_namespace": "un/unece/uncefact/core"},
+                {"path_with_namespace": "un/unece/uncefact/profile"},
+            ],
+        }
+
+    def test_valid_relationship(self):
+        data = validate_relationships(self.snapshot, {
+            "schema_version": "1",
+            "relationships": [{"from": "un/unece/uncefact/profile", "to": "un/unece/uncefact/core", "type": "profile-of"}],
+        })
+        self.assertEqual(data["relationship_count"], 1)
+        self.assertEqual(data["relationships"][0]["provenance"], "declared")
+        self.assertIn("profile of", mermaid_graph(data))
+
+    def test_unknown_internal_endpoint_fails(self):
+        with self.assertRaises(ValueError):
+            validate_relationships(self.snapshot, {
+                "relationships": [{"from": "un/unece/uncefact/missing", "to": "un/unece/uncefact/core", "type": "depends-on"}],
+            })
+
+    def test_unknown_type_fails(self):
+        with self.assertRaises(ValueError):
+            validate_relationships(self.snapshot, {
+                "relationships": [{"from": "un/unece/uncefact/profile", "to": "un/unece/uncefact/core", "type": "magic"}],
+            })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #8.

## What this adds
- declarative `config/relationships.toml` for manually reviewed cross-project relationships
- explicit relationship vocabulary (`depends-on`, `profile-of`, `semantic-dependency`, `trust-infrastructure-dependency`, `related-to`)
- live validation of declared internal endpoints against the discovered portfolio
- failure on unknown internal projects or unsupported relationship types
- provenance-aware `relationships.json`
- generated Mermaid graph source in `relationships.mmd`
- dedicated Pages relationship table/view
- relationship evidence included in the retained portfolio artifact
- unit coverage for valid relationships and validation failures
- `v0.5.0 — Ramganga` release manifest

## Evidence boundary
Relationships are declared governance inputs, not facts inferred from GitLab activity. They do not by themselves assert trust, authority, compatibility, or assurance.

On merge, the live Pages workflow will validate every declaration against the current UN/CEFACT portfolio before publishing, and the release workflow will publish `v0.5.0 — Ramganga`.