### PR TITLE
feat: add v0.6.0 Gandaki impact propagation

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -39,6 +39,8 @@ jobs:
         run: python scripts/build_site.py
       - name: Validate and publish relationships
         run: python scripts/build_relationships.py
+      - name: Derive portfolio review obligations
+        run: python scripts/build_impacts.py
       - name: Advance baseline
         run: |
           mkdir -p .state
@@ -57,6 +59,7 @@ jobs:
             reports/latest/changes.json
             site/relationships.json
             site/relationships.mmd
+            site/impacts.json
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.5.0"
+version = "0.6.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.6.0.yaml
+++ b/releases/v0.6.0.yaml
@@ -1,0 +1,5 @@
+version: v0.6.0
+codename: Gandak
+status: release
+summary: Deterministic propagation of observed structural changes across declared dependencies into provenance-preserving review obligations and informational impact evidence.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/releases/v0.6.0.yaml
+++ b/releases/v0.6.0.yaml
@@ -1,5 +1,5 @@
 version: v0.6.0
-codename: Gandak
+codename: Gandaki
 status: release
 summary: Deterministic propagation of observed structural changes across declared dependencies into provenance-preserving review obligations and informational impact evidence.
 source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_impacts.py
+++ b/scripts/build_impacts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from html import escape
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.impacts import propagate_impacts
+
+
+def render(data: dict) -> str:
+    rows = []
+    for item in data.get("review_obligations", []):
+        rows.append(
+            "<tr>"
+            f"<td><code>{escape(item['review_project'])}</code></td>"
+            f"<td><code>{escape(item['changed_project'])}</code></td>"
+            f"<td>{escape(item['relationship_type'])}</td>"
+            f"<td>{escape(item['change_type'])}</td>"
+            f"<td>{escape(item['reason'])}</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append('<tr><td colspan="5">No direct review obligations in this observation.</td></tr>')
+    info_count = data.get("summary", {}).get("informational", 0)
+    return f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Impact Review</title>
+<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
+<body><p><a href="index.html">← Portfolio</a> · <a href="relationships.html">Relationships</a></p><h1>Portfolio impact review obligations</h1>
+<p>These are deterministic review obligations derived from observed structural change and declared dependency relationships. They are not assurance failures, compatibility conclusions, or trust decisions.</p>
+<div class="note">{data.get('summary',{}).get('review_obligations',0)} direct review obligation(s); {info_count} informational event(s). Machine-readable evidence: <a href="impacts.json">impacts.json</a>.</div>
+<table><thead><tr><th>Review project</th><th>Changed dependency</th><th>Relationship</th><th>Observed change</th><th>Why review</th></tr></thead><tbody>{''.join(rows)}</tbody></table>
+</body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Derive review obligations from change and relationship evidence")
+    parser.add_argument("--changes", type=Path, default=ROOT / "reports" / "latest" / "changes.json")
+    parser.add_argument("--relationships", type=Path, default=ROOT / "site" / "relationships.json")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+    changes = json.loads(args.changes.read_text(encoding="utf-8"))
+    relationships = json.loads(args.relationships.read_text(encoding="utf-8"))
+    data = propagate_impacts(changes, relationships)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "impacts.json").write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "impacts.html").write_text(render(data), encoding="utf-8")
+    print(f"published {data['summary']['review_obligations']} review obligations and {data['summary']['informational']} informational events")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/impacts.py
+++ b/src/uncefact_portfolio_monitor/impacts.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+PROPAGATING_TYPES = {
+    "depends-on",
+    "profile-of",
+    "semantic-dependency",
+    "trust-infrastructure-dependency",
+}
+
+
+def _observed_structural_changes(changes: dict[str, Any]) -> list[dict[str, Any]]:
+    observed: list[dict[str, Any]] = []
+    for kind in ("added", "removed", "changed"):
+        for item in changes.get(kind, []):
+            path = item.get("path_with_namespace")
+            if path:
+                observed.append({"project": path, "change_type": kind, "evidence": item})
+    return observed
+
+
+def propagate_impacts(changes: dict[str, Any], relationships: dict[str, Any]) -> dict[str, Any]:
+    observed = _observed_structural_changes(changes)
+    rels = relationships.get("relationships", [])
+    obligations: list[dict[str, Any]] = []
+    informational: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str, str]] = set()
+
+    for change in observed:
+        changed_project = change["project"]
+        for rel in rels:
+            kind = rel.get("type")
+            source = rel.get("from")
+            target = rel.get("to")
+            if kind in PROPAGATING_TYPES and target == changed_project:
+                key = (source, target, kind, change["change_type"])
+                if key not in seen:
+                    seen.add(key)
+                    obligations.append({
+                        "review_project": source,
+                        "changed_project": target,
+                        "relationship_type": kind,
+                        "change_type": change["change_type"],
+                        "reason": "observed structural change in declared dependency",
+                        "change_evidence": change["evidence"],
+                        "relationship_provenance": rel.get("provenance", "declared"),
+                    })
+            elif kind == "related-to" and changed_project in {source, target}:
+                peer = target if changed_project == source else source
+                informational.append({
+                    "project": peer,
+                    "changed_project": changed_project,
+                    "relationship_type": kind,
+                    "change_type": change["change_type"],
+                    "reason": "related project changed; no dependency is asserted",
+                })
+
+    for item in changes.get("activity_advanced", []):
+        path = item.get("path_with_namespace")
+        if path:
+            informational.append({
+                "project": path,
+                "changed_project": path,
+                "relationship_type": None,
+                "change_type": "activity_advanced",
+                "reason": "repository activity advanced without observed structural metadata change",
+            })
+
+    obligations.sort(key=lambda x: (x["review_project"] or "", x["changed_project"] or "", x["relationship_type"] or ""))
+    informational.sort(key=lambda x: (x["project"] or "", x["changed_project"] or "", x["change_type"] or ""))
+    return {
+        "schema_version": "1",
+        "generated_from": {
+            "changes_current_generated_at": changes.get("current_generated_at"),
+            "relationships_generated_from": relationships.get("generated_from"),
+        },
+        "provenance": "derived-from-observed-change-and-declared-relationships",
+        "summary": {
+            "review_obligations": len(obligations),
+            "informational": len(informational),
+        },
+        "review_obligations": obligations,
+        "informational": informational,
+        "assurance_boundary": "Review obligations are impact candidates, not assurance failures or trust conclusions.",
+    }

--- a/tests/test_impacts.py
+++ b/tests/test_impacts.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.impacts import propagate_impacts
+
+
+class ImpactTests(unittest.TestCase):
+    def setUp(self):
+        self.relationships = {
+            "generated_from": "2026-08-25T00:00:00Z",
+            "relationships": [
+                {"from": "profile", "to": "core", "type": "profile-of", "provenance": "declared"},
+                {"from": "consumer", "to": "profile", "type": "depends-on", "provenance": "declared"},
+                {"from": "peer", "to": "core", "type": "related-to", "provenance": "declared"},
+                {"from": "core", "to": "consumer", "type": "depends-on", "provenance": "declared"},
+            ],
+        }
+
+    def test_dependency_change_creates_direct_obligation_only(self):
+        data = propagate_impacts({
+            "current_generated_at": "2026-08-25T01:00:00Z",
+            "added": [], "removed": [],
+            "changed": [{"path_with_namespace": "core", "fields": {"default_branch": {"before": "master", "after": "main"}}}],
+            "activity_advanced": [],
+        }, self.relationships)
+        self.assertEqual(data["summary"]["review_obligations"], 1)
+        self.assertEqual(data["review_obligations"][0]["review_project"], "profile")
+        self.assertEqual(data["review_obligations"][0]["changed_project"], "core")
+        self.assertEqual(data["summary"]["informational"], 1)
+
+    def test_activity_only_is_informational(self):
+        data = propagate_impacts({
+            "current_generated_at": "2026-08-25T01:00:00Z",
+            "added": [], "removed": [], "changed": [],
+            "activity_advanced": [{"path_with_namespace": "core", "before": "a", "after": "b"}],
+        }, self.relationships)
+        self.assertEqual(data["summary"]["review_obligations"], 0)
+        self.assertEqual(data["summary"]["informational"], 1)
+
+    def test_no_change_produces_no_obligation(self):
+        data = propagate_impacts({
+            "current_generated_at": "2026-08-25T01:00:00Z",
+            "added": [], "removed": [], "changed": [], "activity_advanced": [],
+        }, self.relationships)
+        self.assertEqual(data["summary"], {"review_obligations": 0, "informational": 0})
+
+    def test_cycle_does_not_recurse_or_duplicate(self):
+        data = propagate_impacts({
+            "current_generated_at": "2026-08-25T01:00:00Z",
+            "added": [], "removed": [],
+            "changed": [{"path_with_namespace": "consumer", "fields": {"topics": {"before": [], "after": ["x"]}}}],
+            "activity_advanced": [],
+        }, self.relationships)
+        self.assertEqual(data["summary"]["review_obligations"], 1)
+        self.assertEqual(data["review_obligations"][0]["review_project"], "core")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9.

## What this adds
- deterministic propagation from observed structural portfolio change across declared dependency relationships
- direct review obligations only when a changed project is the dependency target of `depends-on`, `profile-of`, `semantic-dependency`, or `trust-infrastructure-dependency`
- `related-to` relationships retained as informational context only
- activity-only advancement retained as informational evidence and never promoted to a review obligation
- provenance-preserving `impacts.json` with exact change evidence and declared relationship provenance
- dedicated Pages impact-review view
- cycle-safe, non-recursive propagation semantics
- unit coverage for dependency propagation, no-change behavior, activity-only behavior, and cycles
- retained impact evidence in the portfolio artifact
- `v0.6.0 — Gandak` release manifest

## Assurance boundary
A review obligation is an impact candidate, not an assurance failure, incompatibility conclusion, trust decision, or evidence of normative breakage. It means only that an observed structural change occurred in a declared dependency and the dependent project should be reviewed.

On merge, the live scan will derive impact evidence from the current observation and relationship graph, redeploy Pages, and publish `v0.6.0 — Gandak`.