### PR TITLE
feat: add v0.7.0 Gomti evidence-policy findings

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -41,6 +41,8 @@ jobs:
         run: python scripts/build_relationships.py
       - name: Derive portfolio review obligations
         run: python scripts/build_impacts.py
+      - name: Evaluate evidence policies and publish findings
+        run: python scripts/build_findings.py
       - name: Advance baseline
         run: |
           mkdir -p .state
@@ -60,6 +62,7 @@ jobs:
             site/relationships.json
             site/relationships.mmd
             site/impacts.json
+            site/findings.json
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/config/finding-policies.toml
+++ b/config/finding-policies.toml
@@ -1,0 +1,17 @@
+schema_version = "1"
+
+[[policies]]
+id = "UCF-PF-001"
+title = "Trust infrastructure dependency changed"
+severity = "high"
+relationship_types = ["trust-infrastructure-dependency"]
+change_types = ["added", "removed", "changed"]
+description = "A project with a declared trust-infrastructure dependency requires tracked disposition after structural change in that dependency."
+
+[[policies]]
+id = "UCF-PF-002"
+title = "Declared specification dependency changed"
+severity = "medium"
+relationship_types = ["depends-on", "profile-of", "semantic-dependency"]
+change_types = ["added", "removed", "changed"]
+description = "A project with a declared specification, profile, or semantic dependency requires tracked disposition after structural change in that dependency."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.6.0"
+version = "0.7.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.7.0.yaml
+++ b/releases/v0.7.0.yaml
@@ -1,0 +1,5 @@
+version: v0.7.0
+codename: Gomti
+status: release
+summary: Deterministic evidence-policy evaluation producing stable provenance-preserving portfolio findings from review obligations without aggregate scoring.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_findings.py
+++ b/scripts/build_findings.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from html import escape
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.findings import derive_findings
+
+
+def render(data: dict) -> str:
+    rows = []
+    for item in data.get("findings", []):
+        rows.append(
+            "<tr>"
+            f"<td><code>{escape(item['finding_id'])}</code></td>"
+            f"<td>{escape(item['severity'])}</td>"
+            f"<td><code>{escape(item['subject_project'])}</code></td>"
+            f"<td><code>{escape(item['dependency_project'])}</code></td>"
+            f"<td>{escape(item['relationship_type'])}</td>"
+            f"<td>{escape(item['change_type'])}</td>"
+            f"<td><code>{escape(item['policy_id'])}</code></td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append('<tr><td colspan="7">No policy-matched findings in this observation.</td></tr>')
+    summary = data.get("summary", {})
+    by_severity = summary.get("by_severity", {})
+    return f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Findings</title>
+<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1250px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
+<body><p><a href="index.html">← Portfolio</a> · <a href="relationships.html">Relationships</a> · <a href="impacts.html">Impact review</a></p><h1>Evidence-backed portfolio findings</h1>
+<p>Findings are deterministic matches between declared evidence policies and current review obligations. They require tracked disposition but are not automatically compatibility failures, assurance failures, or trust decisions.</p>
+<div class="note">{summary.get('open_findings',0)} open finding(s): {by_severity.get('critical',0)} critical, {by_severity.get('high',0)} high, {by_severity.get('medium',0)} medium, {by_severity.get('low',0)} low. Machine-readable evidence: <a href="findings.json">findings.json</a>.</div>
+<table><thead><tr><th>Finding</th><th>Severity</th><th>Review project</th><th>Changed dependency</th><th>Relationship</th><th>Change</th><th>Policy</th></tr></thead><tbody>{''.join(rows)}</tbody></table>
+<p><small>{escape(data.get('assurance_boundary',''))}</small></p>
+</body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Derive findings from review obligations and declared evidence policies")
+    parser.add_argument("--impacts", type=Path, default=ROOT / "site" / "impacts.json")
+    parser.add_argument("--policies", type=Path, default=ROOT / "config" / "finding-policies.toml")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+    impacts = json.loads(args.impacts.read_text(encoding="utf-8"))
+    policies = tomllib.loads(args.policies.read_text(encoding="utf-8"))
+    data = derive_findings(impacts, policies)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "findings.json").write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "findings.html").write_text(render(data), encoding="utf-8")
+    print(f"published {data['summary']['open_findings']} policy-matched findings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/findings.py
+++ b/src/uncefact_portfolio_monitor/findings.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import Any
+
+ALLOWED_SEVERITIES = {"low", "medium", "high", "critical"}
+
+
+def validate_policies(config: dict[str, Any]) -> list[dict[str, Any]]:
+    policies = config.get("policies", [])
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for index, policy in enumerate(policies, start=1):
+        policy_id = str(policy.get("id") or "").strip()
+        severity = str(policy.get("severity") or "").strip()
+        relationship_types = list(policy.get("relationship_types") or [])
+        change_types = list(policy.get("change_types") or [])
+        if not policy_id:
+            errors.append(f"policy {index}: id is required")
+        elif policy_id in seen:
+            errors.append(f"policy {index}: duplicate id {policy_id!r}")
+        else:
+            seen.add(policy_id)
+        if severity not in ALLOWED_SEVERITIES:
+            errors.append(f"policy {index}: unsupported severity {severity!r}")
+        if not relationship_types:
+            errors.append(f"policy {index}: relationship_types is required")
+        if not change_types:
+            errors.append(f"policy {index}: change_types is required")
+        normalized.append({
+            "id": policy_id,
+            "title": str(policy.get("title") or policy_id),
+            "severity": severity,
+            "relationship_types": relationship_types,
+            "change_types": change_types,
+            "description": str(policy.get("description") or ""),
+            "provenance": "declared-policy",
+        })
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return normalized
+
+
+def _finding_id(policy_id: str, obligation: dict[str, Any]) -> str:
+    material = "|".join([
+        policy_id,
+        str(obligation.get("review_project") or ""),
+        str(obligation.get("changed_project") or ""),
+        str(obligation.get("relationship_type") or ""),
+        str(obligation.get("change_type") or ""),
+    ])
+    digest = sha256(material.encode("utf-8")).hexdigest()[:12].upper()
+    return f"{policy_id}-{digest}"
+
+
+def derive_findings(impacts: dict[str, Any], policy_config: dict[str, Any]) -> dict[str, Any]:
+    policies = validate_policies(policy_config)
+    observed_at = impacts.get("generated_from", {}).get("changes_current_generated_at")
+    findings: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for impact_index, obligation in enumerate(impacts.get("review_obligations", [])):
+        for policy in policies:
+            if obligation.get("relationship_type") not in policy["relationship_types"]:
+                continue
+            if obligation.get("change_type") not in policy["change_types"]:
+                continue
+            finding_id = _finding_id(policy["id"], obligation)
+            if finding_id in seen:
+                continue
+            seen.add(finding_id)
+            findings.append({
+                "finding_id": finding_id,
+                "status": "open",
+                "severity": policy["severity"],
+                "title": policy["title"],
+                "policy_id": policy["id"],
+                "subject_project": obligation.get("review_project"),
+                "dependency_project": obligation.get("changed_project"),
+                "relationship_type": obligation.get("relationship_type"),
+                "change_type": obligation.get("change_type"),
+                "reason": policy["description"],
+                "first_observed": observed_at,
+                "last_observed": observed_at,
+                "evidence": {
+                    "impact_ref": f"impacts.json#/review_obligations/{impact_index}",
+                    "change_evidence": obligation.get("change_evidence"),
+                    "relationship_provenance": obligation.get("relationship_provenance"),
+                    "policy_provenance": policy["provenance"],
+                },
+                "provenance": "derived-from-review-obligation-and-declared-policy",
+            })
+
+    findings.sort(key=lambda item: (item["severity"], item["finding_id"]))
+    by_severity = {severity: 0 for severity in ("critical", "high", "medium", "low")}
+    for finding in findings:
+        by_severity[finding["severity"]] += 1
+
+    return {
+        "schema_version": "1",
+        "generated_from": {
+            "impacts": impacts.get("generated_from"),
+            "policy_schema_version": str(policy_config.get("schema_version", "1")),
+        },
+        "provenance": "deterministic-policy-evaluation",
+        "summary": {
+            "open_findings": len(findings),
+            "by_severity": by_severity,
+        },
+        "findings": findings,
+        "assurance_boundary": "A finding is a policy-matched evidence condition requiring tracked disposition; it is not by itself a trust decision or proof of incompatibility.",
+    }

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.findings import derive_findings, validate_policies
+
+
+class FindingTests(unittest.TestCase):
+    def setUp(self):
+        self.impacts = {
+            "generated_from": {"changes_current_generated_at": "2026-08-25T00:00:00Z"},
+            "review_obligations": [{
+                "review_project": "un/unece/uncefact/profile",
+                "changed_project": "un/unece/uncefact/core",
+                "relationship_type": "profile-of",
+                "change_type": "changed",
+                "change_evidence": {"fields": {"default_branch": {"before": "master", "after": "main"}}},
+                "relationship_provenance": "declared",
+            }],
+            "informational": [{"project": "x", "change_type": "activity_advanced"}],
+        }
+        self.policy = {
+            "schema_version": "1",
+            "policies": [{
+                "id": "UCF-PF-002",
+                "title": "Declared specification dependency changed",
+                "severity": "medium",
+                "relationship_types": ["profile-of"],
+                "change_types": ["changed"],
+                "description": "Tracked disposition required.",
+            }],
+        }
+
+    def test_policy_match_creates_evidence_backed_finding(self):
+        data = derive_findings(self.impacts, self.policy)
+        self.assertEqual(data["summary"]["open_findings"], 1)
+        finding = data["findings"][0]
+        self.assertEqual(finding["severity"], "medium")
+        self.assertEqual(finding["policy_id"], "UCF-PF-002")
+        self.assertEqual(finding["evidence"]["relationship_provenance"], "declared")
+        self.assertIn("impact_ref", finding["evidence"])
+
+    def test_finding_id_is_stable(self):
+        first = derive_findings(self.impacts, self.policy)["findings"][0]["finding_id"]
+        second = derive_findings(self.impacts, self.policy)["findings"][0]["finding_id"]
+        self.assertEqual(first, second)
+
+    def test_no_matching_policy_creates_no_finding(self):
+        policy = {"policies": [{
+            "id": "UCF-PF-003", "title": "Other", "severity": "low",
+            "relationship_types": ["semantic-dependency"], "change_types": ["changed"]
+        }]}
+        self.assertEqual(derive_findings(self.impacts, policy)["findings"], [])
+
+    def test_informational_evidence_never_becomes_finding(self):
+        impacts = {"generated_from": self.impacts["generated_from"], "review_obligations": [], "informational": self.impacts["informational"]}
+        self.assertEqual(derive_findings(impacts, self.policy)["findings"], [])
+
+    def test_duplicate_policy_id_is_rejected(self):
+        policy = dict(self.policy)
+        policy["policies"] = self.policy["policies"] * 2
+        with self.assertRaises(ValueError):
+            validate_policies(policy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #16.

## What this adds
- declarative `config/finding-policies.toml` separated from observed evidence
- deterministic finding derivation from `impacts.json` review obligations
- stable finding identifiers derived from policy + subject + dependency + relationship + change type
- explicit severity and policy provenance; no aggregate portfolio score
- complete causal evidence chain embedded in each finding
- `findings.json` machine-readable output and dedicated Pages findings view
- informational events excluded from the finding path by construction
- validation for policy IDs, severities, relationship/change match criteria
- tests for policy match, no-match, stable IDs, informational-only evidence, and duplicate policy IDs
- Actions integration retaining findings evidence
- `v0.7.0 — Gomti` release manifest

## Assurance boundary
A finding is a policy-matched evidence condition requiring tracked disposition. It is not, by itself, proof of incompatibility, an assurance failure, or a trust decision.

This release intentionally establishes the internal evidence-policy layer before external standards dependency monitoring so later external evidence can enter the same deterministic policy framework.