### PR TITLE
feat: add v0.8.0 Nandakini external dependency inventory

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -43,6 +43,8 @@ jobs:
         run: python scripts/build_impacts.py
       - name: Evaluate evidence policies and publish findings
         run: python scripts/build_findings.py
+      - name: Validate and publish external dependencies
+        run: python scripts/build_external_dependencies.py
       - name: Advance baseline
         run: |
           mkdir -p .state
@@ -63,6 +65,7 @@ jobs:
             site/relationships.mmd
             site/impacts.json
             site/findings.json
+            site/external-dependencies.json
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/config/external-dependencies.toml
+++ b/config/external-dependencies.toml
@@ -1,0 +1,25 @@
+schema_version = "1"
+
+[[dependencies]]
+id = "w3c-did-resolution"
+name = "W3C DID Resolution 1.0"
+url = "https://www.w3.org/TR/did-resolution/"
+type = "technical-resolution-dependency"
+affected_projects = ["un/unece/uncefact/gtr", "un/unece/uncefact/spec-untp"]
+note = "DID resolution is technical identifier-control evidence and must remain distinct from registrar authority evidence."
+
+[[dependencies]]
+id = "w3c-recognized-entities"
+name = "W3C Verifiable Credentials Recognized Entities"
+url = "https://w3c.github.io/vc-recognized-entities/"
+type = "trust-model-dependency"
+affected_projects = ["un/unece/uncefact/gtr", "un/unece/uncefact/spec-untp"]
+note = "Recognized-entity work may affect registrar-recognition and Digital Identity Anchor trust semantics."
+
+[[dependencies]]
+id = "toip-trqp"
+name = "Trust Registry Query Protocol"
+url = "https://github.com/trustoverip/tswg-trust-registry-protocol"
+type = "protocol-alignment"
+affected_projects = ["un/unece/uncefact/gtr"]
+note = "GRID/GTR may profile or align with TRQP for registry-query and lifecycle semantics without making governance obligations protocol-dependent."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.7.0"
+version = "0.8.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.8.0.yaml
+++ b/releases/v0.8.0.yaml
@@ -1,0 +1,5 @@
+version: v0.8.0
+codename: Nandakini
+status: release
+summary: Declarative validated external standards dependency inventory published as evidence and Pages context without asserting external change or incompatibility.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_external_dependencies.py
+++ b/scripts/build_external_dependencies.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from html import escape
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.external import validate_external_dependencies
+
+
+def render(data: dict) -> str:
+    rows = []
+    for dep in data.get("dependencies", []):
+        projects = "<br>".join(f"<code>{escape(p)}</code>" for p in dep["affected_projects"])
+        rows.append(
+            "<tr>"
+            f"<td><a href=\"{escape(dep['url'], quote=True)}\">{escape(dep['name'])}</a><div><code>{escape(dep['id'])}</code></div></td>"
+            f"<td>{escape(dep['type'])}</td><td>{projects}</td><td>{escape(dep['note'])}</td></tr>"
+        )
+    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT External Dependencies</title><style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
+<body><p><a href="index.html">← Portfolio</a> · <a href="findings.html">Findings</a></p><h1>Declared external standards dependencies</h1>
+<p>This inventory identifies external specifications or protocols that may materially affect internal projects. It does not claim that an external source changed or that an internal project is incompatible.</p>
+<div class="note">{data.get('dependency_count',0)} declared dependency record(s). Machine-readable evidence: <a href="external-dependencies.json">external-dependencies.json</a>.</div>
+<table><thead><tr><th>External source</th><th>Type</th><th>Affected projects</th><th>Review note</th></tr></thead><tbody>{''.join(rows)}</tbody></table></body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snapshot", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--config", type=Path, default=ROOT / "config" / "external-dependencies.toml")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+    snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    config = tomllib.loads(args.config.read_text(encoding="utf-8"))
+    data = validate_external_dependencies(snapshot, config)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "external-dependencies.json").write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "external-dependencies.html").write_text(render(data), encoding="utf-8")
+    print(f"published {data['dependency_count']} external dependencies")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/external.py
+++ b/src/uncefact_portfolio_monitor/external.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+ALLOWED_TYPES = {
+    "technical-resolution-dependency",
+    "trust-model-dependency",
+    "protocol-alignment",
+    "semantic-dependency",
+    "normative-dependency",
+}
+
+
+def validate_external_dependencies(snapshot: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    projects = {item.get("path_with_namespace") for item in snapshot.get("projects", [])}
+    dependencies = config.get("dependencies", [])
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for index, dep in enumerate(dependencies, start=1):
+        dep_id = dep.get("id")
+        dep_type = dep.get("type")
+        url = dep.get("url", "")
+        affected = dep.get("affected_projects", [])
+        if not dep_id or dep_id in seen:
+            errors.append(f"dependency {index}: missing or duplicate id {dep_id!r}")
+        else:
+            seen.add(dep_id)
+        if dep_type not in ALLOWED_TYPES:
+            errors.append(f"dependency {index}: unsupported type {dep_type!r}")
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            errors.append(f"dependency {index}: invalid URL {url!r}")
+        if not affected:
+            errors.append(f"dependency {index}: affected_projects must not be empty")
+        unknown = sorted(project for project in affected if project not in projects)
+        if unknown:
+            errors.append(f"dependency {index}: unknown affected projects {unknown!r}")
+        normalized.append({
+            "id": dep_id,
+            "name": dep.get("name", dep_id),
+            "url": url,
+            "type": dep_type,
+            "affected_projects": sorted(affected),
+            "note": dep.get("note", ""),
+            "provenance": "declared-external-dependency",
+        })
+
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    normalized.sort(key=lambda item: item["id"])
+    return {
+        "schema_version": str(config.get("schema_version", "1")),
+        "generated_from": snapshot.get("generated_at"),
+        "provenance": "declared-external-dependency-configuration",
+        "dependency_count": len(normalized),
+        "dependencies": normalized,
+        "assurance_boundary": "External dependency declarations identify review context; they do not assert current external change, incompatibility, or assurance failure.",
+    }

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.external import validate_external_dependencies
+
+
+class ExternalDependencyTests(unittest.TestCase):
+    def setUp(self):
+        self.snapshot = {"generated_at": "2026-08-25T00:00:00Z", "projects": [{"path_with_namespace": "un/unece/uncefact/gtr"}]}
+
+    def test_valid_dependency(self):
+        data = validate_external_dependencies(self.snapshot, {"dependencies": [{"id": "x", "name": "X", "url": "https://example.org/spec", "type": "normative-dependency", "affected_projects": ["un/unece/uncefact/gtr"]}]})
+        self.assertEqual(data["dependency_count"], 1)
+        self.assertEqual(data["dependencies"][0]["provenance"], "declared-external-dependency")
+
+    def test_unknown_project_fails(self):
+        with self.assertRaises(ValueError):
+            validate_external_dependencies(self.snapshot, {"dependencies": [{"id": "x", "url": "https://example.org", "type": "normative-dependency", "affected_projects": ["missing"]}]})
+
+    def test_duplicate_id_fails(self):
+        dep = {"id": "x", "url": "https://example.org", "type": "normative-dependency", "affected_projects": ["un/unece/uncefact/gtr"]}
+        with self.assertRaises(ValueError):
+            validate_external_dependencies(self.snapshot, {"dependencies": [dep, dep]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #10.

Adds a validated declarative inventory of external standards/protocol dependencies, publishes machine-readable and Pages evidence, and retains strict assurance boundaries: declarations identify review context only and do not assert external change, incompatibility, or failure.

Release: `v0.8.0 — Nandakini`.