### PR TITLE
feat: add v0.9.0 Yamuna findings lifecycle and weekly report

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Restore previous portfolio baseline
+      - name: Restore previous portfolio state
         uses: actions/cache/restore@v4
         with:
-          path: .state/portfolio.json
+          path: .state
           key: portfolio-baseline-${{ github.run_id }}
           restore-keys: |
             portfolio-baseline-
@@ -45,14 +45,17 @@ jobs:
         run: python scripts/build_findings.py
       - name: Validate and publish external dependencies
         run: python scripts/build_external_dependencies.py
-      - name: Advance baseline
+      - name: Update findings lifecycle and weekly report
+        run: python scripts/build_lifecycle_report.py
+      - name: Advance persistent state
         run: |
           mkdir -p .state
           cp reports/latest/portfolio.json .state/portfolio.json
-      - name: Save current portfolio baseline
+          cp site/findings-lifecycle.json .state/findings-lifecycle.json
+      - name: Save current portfolio state
         uses: actions/cache/save@v4
         with:
-          path: .state/portfolio.json
+          path: .state
           key: portfolio-baseline-${{ github.run_id }}
       - name: Upload portfolio evidence
         uses: actions/upload-artifact@v4
@@ -65,7 +68,9 @@ jobs:
             site/relationships.mmd
             site/impacts.json
             site/findings.json
+            site/findings-lifecycle.json
             site/external-dependencies.json
+            site/weekly-report.md
           retention-days: 30
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.8.0"
+version = "0.9.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v0.9.0.yaml
+++ b/releases/v0.9.0.yaml
@@ -1,0 +1,5 @@
+version: v0.9.0
+codename: Yamuna
+status: release
+summary: Persistent findings lifecycle with active/resolved history and evidence-linked weekly portfolio assurance reporting.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_lifecycle_report.py
+++ b/scripts/build_lifecycle_report.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from html import escape
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.lifecycle import update_lifecycle
+
+
+def _read(path: Path, default: dict) -> dict:
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else default
+
+
+def markdown_report(portfolio: dict, changes: dict, impacts: dict, lifecycle: dict, external: dict) -> str:
+    s = lifecycle.get("summary", {})
+    c = changes.get("summary", {})
+    return f"""# UN/CEFACT Portfolio Assurance Report
+
+Observation: {portfolio.get('generated_at','unknown')}
+
+## Portfolio summary
+
+- Discovered projects: {portfolio.get('project_count', len(portfolio.get('projects', [])))}
+- Structural changes: {int(c.get('added',0))+int(c.get('removed',0))+int(c.get('changed',0))}
+- Activity-only advancements: {c.get('activity_advanced',0)}
+- Direct review obligations: {impacts.get('summary',{}).get('review_obligations',0)}
+- Active findings: {s.get('active',0)}
+- Resolved findings retained: {s.get('resolved',0)}
+- Declared external dependencies: {external.get('dependency_count',0)}
+
+## Active findings
+
+{_finding_lines(lifecycle, 'active')}
+
+## Resolved findings retained
+
+{_finding_lines(lifecycle, 'resolved')}
+
+## Interpretation boundary
+
+This report is generated from observable repository evidence, declared relationships, declared evidence policies, and declared external dependency context. Findings require tracked disposition but are not automatically compatibility failures, assurance failures, or trust decisions.
+"""
+
+
+def _finding_lines(lifecycle: dict, status: str) -> str:
+    records = [r for r in lifecycle.get("records", []) if r.get("status") == status]
+    if not records:
+        return "_None in this observation._"
+    return "\n".join(f"- **{r.get('severity','unknown').upper()}** `{r['finding_id']}` — `{r.get('subject_project')}` reviewing `{r.get('dependency_project')}` ({r.get('relationship_type')}, {r.get('change_type')}); observed {r.get('observation_count',1)} time(s)." for r in records)
+
+
+def html_report(markdown: str, lifecycle: dict) -> str:
+    lines = "".join(f"<p>{escape(line)}</p>" if line and not line.startswith('#') and not line.startswith('- ') else (f"<h2>{escape(line[3:])}</h2>" if line.startswith('## ') else (f"<h1>{escape(line[2:])}</h1>" if line.startswith('# ') else (f"<li>{escape(line[2:])}</li>" if line.startswith('- ') else ""))) for line in markdown.splitlines())
+    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>UN/CEFACT Portfolio Assurance Report</title><style>body{{font:15px/1.6 system-ui,sans-serif;max-width:1000px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head><body><p><a href="index.html">← Portfolio</a> · <a href="findings.html">Current findings</a> · <a href="external-dependencies.html">External dependencies</a></p><div class="note">Machine-readable lifecycle: <a href="findings-lifecycle.json">findings-lifecycle.json</a> · Markdown report: <a href="weekly-report.md">weekly-report.md</a></div>{lines}<p><small>{escape(lifecycle.get('assurance_boundary',''))}</small></p></body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--findings", type=Path, default=ROOT / "site" / "findings.json")
+    parser.add_argument("--previous", type=Path, default=ROOT / ".state" / "findings-lifecycle.json")
+    parser.add_argument("--portfolio", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
+    parser.add_argument("--changes", type=Path, default=ROOT / "reports" / "latest" / "changes.json")
+    parser.add_argument("--impacts", type=Path, default=ROOT / "site" / "impacts.json")
+    parser.add_argument("--external", type=Path, default=ROOT / "site" / "external-dependencies.json")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
+    args = parser.parse_args()
+    current = _read(args.findings, {"findings": []})
+    previous = _read(args.previous, {})
+    lifecycle = update_lifecycle(current, previous)
+    portfolio = _read(args.portfolio, {})
+    changes = _read(args.changes, {"summary": {}})
+    impacts = _read(args.impacts, {"summary": {}})
+    external = _read(args.external, {"dependency_count": 0})
+    md = markdown_report(portfolio, changes, impacts, lifecycle, external)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "findings-lifecycle.json").write_text(json.dumps(lifecycle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "weekly-report.md").write_text(md, encoding="utf-8")
+    (args.output_dir / "weekly-report.html").write_text(html_report(md, lifecycle), encoding="utf-8")
+    print(f"lifecycle: {lifecycle['summary']['active']} active, {lifecycle['summary']['resolved']} resolved")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uncefact_portfolio_monitor/lifecycle.py
+++ b/src/uncefact_portfolio_monitor/lifecycle.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def update_lifecycle(current_findings: dict[str, Any], previous: dict[str, Any] | None) -> dict[str, Any]:
+    observed_at = current_findings.get("generated_from", {}).get("observation") or current_findings.get("generated_at")
+    prior_records = {r["finding_id"]: dict(r) for r in (previous or {}).get("records", []) if r.get("finding_id")}
+    current = {f["finding_id"]: f for f in current_findings.get("findings", []) if f.get("finding_id")}
+    records: list[dict[str, Any]] = []
+
+    for finding_id, finding in current.items():
+        prior = prior_records.get(finding_id)
+        records.append({
+            "finding_id": finding_id,
+            "status": "active",
+            "severity": finding.get("severity"),
+            "policy_id": finding.get("policy_id"),
+            "subject_project": finding.get("subject_project"),
+            "dependency_project": finding.get("dependency_project"),
+            "relationship_type": finding.get("relationship_type"),
+            "change_type": finding.get("change_type"),
+            "first_observed": (prior or {}).get("first_observed") or observed_at,
+            "last_observed": observed_at,
+            "observation_count": int((prior or {}).get("observation_count", 0)) + 1,
+            "resolved_at": None,
+            "evidence": finding,
+        })
+
+    for finding_id, prior in prior_records.items():
+        if finding_id in current:
+            continue
+        prior["status"] = "resolved"
+        prior["resolved_at"] = prior.get("resolved_at") or observed_at
+        records.append(prior)
+
+    records.sort(key=lambda r: (r["status"] != "active", r.get("severity") or "", r["finding_id"]))
+    active = sum(1 for r in records if r["status"] == "active")
+    resolved = sum(1 for r in records if r["status"] == "resolved")
+    return {
+        "schema_version": "1",
+        "observed_at": observed_at,
+        "summary": {"active": active, "resolved": resolved, "total_records": len(records)},
+        "records": records,
+        "assurance_boundary": "Lifecycle status records evidence persistence and disposition state; it does not turn a finding into a compatibility or trust conclusion.",
+    }

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from uncefact_portfolio_monitor.lifecycle import update_lifecycle
+
+
+class LifecycleTests(unittest.TestCase):
+    def finding(self, finding_id="PF-1"):
+        return {"finding_id": finding_id, "severity": "high", "policy_id": "p1", "subject_project": "profile", "dependency_project": "core", "relationship_type": "profile-of", "change_type": "changed"}
+
+    def test_new_finding_becomes_active(self):
+        data = update_lifecycle({"generated_from": {"observation": "2026-08-25T00:00:00Z"}, "findings": [self.finding()]}, None)
+        self.assertEqual(data["summary"]["active"], 1)
+        self.assertEqual(data["records"][0]["observation_count"], 1)
+
+    def test_repeated_finding_preserves_first_seen_and_increments(self):
+        previous = {"records": [{**self.finding(), "status": "active", "first_observed": "2026-08-24T00:00:00Z", "last_observed": "2026-08-24T00:00:00Z", "observation_count": 1, "resolved_at": None, "evidence": self.finding()}]}
+        data = update_lifecycle({"generated_from": {"observation": "2026-08-25T00:00:00Z"}, "findings": [self.finding()]}, previous)
+        record = data["records"][0]
+        self.assertEqual(record["first_observed"], "2026-08-24T00:00:00Z")
+        self.assertEqual(record["observation_count"], 2)
+
+    def test_missing_current_finding_resolves_but_is_retained(self):
+        previous = {"records": [{**self.finding(), "status": "active", "first_observed": "2026-08-24T00:00:00Z", "last_observed": "2026-08-24T00:00:00Z", "observation_count": 1, "resolved_at": None, "evidence": self.finding()}]}
+        data = update_lifecycle({"generated_from": {"observation": "2026-08-25T00:00:00Z"}, "findings": []}, previous)
+        self.assertEqual(data["summary"]["resolved"], 1)
+        self.assertEqual(data["records"][0]["status"], "resolved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #20.

Adds persistent findings lifecycle state with first/last observed timestamps, active/resolved status, observation counts, retained resolved history, and evidence-linked weekly Markdown/HTML reporting. Persistent state is stored via the existing Actions cache and published lifecycle/report outputs remain traceable to current evidence.

Release: `v0.9.0 — Yamuna`.