### PR TITLE
release: stabilize v1.0.0 Alaknanda evidence contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
           for manifest in releases/v*.yaml; do
             python scripts/release_from_manifest.py "$manifest"
           done
+      - name: Validate v1 release readiness
+        run: python scripts/release_readiness.py

--- a/README.md
+++ b/README.md
@@ -1,50 +1,90 @@
 # UN/CEFACT Portfolio Monitor
 
-Evidence-driven monitoring of the UN/CEFACT open-source portfolio: repository health, specification dependencies, cross-project change impact, semantic alignment, and portfolio assurance.
+Evidence-driven monitoring of the UN/CEFACT open-source portfolio: live project discovery, cross-project change impact, explicit dependency context, policy-matched findings, lifecycle history, and portfolio reporting.
+
+**Published monitor:** https://sankarshanmukhopadhyay.github.io/uncefact-portfolio-monitor/
+
+## v1.0 operating model
+
+```text
+UN/CEFACT GitLab discovery
+        ↓
+retained observation comparison
+        ↓
+observed structural change
+        ↓
+declared internal relationships
+        ↓
+direct review obligations
+        ↓
+declared evidence policies
+        ↓
+policy-matched findings
+        ↓
+persistent active/resolved lifecycle
+        ↓
+weekly portfolio assurance report
+```
+
+Declared external standards dependencies are published alongside this chain as review context. v1.0 does not claim automated external-change detection.
 
 ## Design principles
 
 1. **Evidence before scores.** Findings must point to inspectable evidence.
-2. **Portfolio coherence over activity volume.** A green repository can still create a cross-project risk.
-3. **Declarative relationships.** Portfolio membership and dependencies live in configuration, not hard-coded Python.
+2. **Portfolio coherence over activity volume.** A green repository can still create a cross-project review obligation.
+3. **Declarations remain declarations.** Relationships, finding policies, and external dependencies are reviewed governance inputs, not inferred facts.
 4. **Provider neutrality.** CI, repository inspection, specification checks, RAHP, and future analyzers may contribute evidence; none is the universal source of truth.
-5. **Human review for material inference.** The monitor identifies review obligations; it does not silently convert change into trust conclusions.
+5. **Human review for material inference.** The monitor does not silently convert change into incompatibility or trust conclusions.
+6. **History is retained.** Findings can resolve without disappearing from the evidence lifecycle.
 
-## Current capability
+## Evidence contract
 
-`v0.2.x` adds dynamic discovery of the public UN/CEFACT GitLab portfolio under `un/unece/uncefact`.
+The stable v1 evidence layers and invariants are defined in [docs/EVIDENCE-CONTRACT.md](docs/EVIDENCE-CONTRACT.md).
 
-Run locally:
+The core machine-readable outputs are:
 
-```bash
-python scripts/discover_portfolio.py
-```
+- `portfolio.json` — discovered portfolio inventory;
+- `changes.json` — structural/activity comparison with the previous observation;
+- `relationships.json` — declared internal portfolio relationships;
+- `impacts.json` — direct review obligations;
+- `findings.json` — policy-matched current findings;
+- `findings-lifecycle.json` — retained active/resolved lifecycle;
+- `external-dependencies.json` — declared external standards/protocol context;
+- `weekly-report.md` — evidence-linked human-readable portfolio report.
 
-The collector:
+A finding is a policy-matched evidence condition requiring tracked disposition. It is **not automatically an incompatibility conclusion, assurance failure, or trust decision**.
 
-- reads the namespace from `config/portfolio.toml`;
-- follows GitLab pagination;
-- includes subgroups;
-- normalizes evidence-relevant project metadata;
-- writes stable JSON to `reports/latest/portfolio.json`.
+## Operator guide
 
-GitHub Actions also runs the scan weekly and on demand, retaining the resulting snapshot as an artifact for later inspection and comparison.
+See [docs/OPERATIONS.md](docs/OPERATIONS.md) for the complete run sequence, interpretation order, failure handling, release operation, and v1 limitations.
 
-## Development flow
+The scheduled workflow runs weekly and is also manually dispatchable. A local run requires Python 3.11+.
+
+## Development and release flow
 
 Substantive work follows:
 
 `Issue → branch → pull request → CI → merge → release manifest → GitHub Actions release`
 
-The repository's first README commit was the only bootstrap exception required to make branch/PR development possible.
+Release manifests are validated by CI. The release workflow creates tags and GitHub Releases after a valid new manifest reaches `main`.
 
-## Release codenames
+## v1.0 limitations and extension points
 
-Each release receives a randomly selected codename from the direct pages in Wikipedia's `Category:Tributaries of the Ganges`. The selected name is recorded in the release manifest, making the outcome auditable even though selection is random.
+v1.0 intentionally does **not** automatically score repository health, poll external standards for semantic changes, infer normative compatibility, perform recursive multi-hop impact propagation, or make relying-party trust decisions.
 
-- **v0.1.0 — Tamsa**: foundation, governance, CI, and release automation.
-- **v0.2.0 — Ghaghara**: dynamic GitLab portfolio discovery and scan artifacts.
+Future evidence providers may add role-aware repository checks, semantic/schema drift analysis, external-source change polling, and additional specification pressure tests, but they must preserve the v1 evidence boundaries.
 
-## Roadmap
+## Release history
 
-Next milestones add change detection, repository-health evidence, explicit cross-project relationships, impact propagation, and portfolio findings. The monitor will remain evidence-driven and will not treat any single assurance provider as the portfolio-wide source of truth.
+- **v0.1.0 — Tamsa** — foundation, CI, release automation.
+- **v0.2.0 — Ghaghara** — dynamic GitLab portfolio discovery.
+- **v0.3.0 — Varuna** — published GitHub Pages portfolio.
+- **v0.4.0 — Kosi** — retained baseline and change detection.
+- **v0.5.0 — Ramganga** — declared internal relationship graph.
+- **v0.6.0 — Gandaki** — direct dependency-aware review obligations.
+- **v0.7.0 — Gomti** — deterministic evidence-policy findings.
+- **v0.8.0 — Nandakini** — declared external standards dependency inventory.
+- **v0.9.0 — Yamuna** — findings lifecycle and weekly report.
+- **v1.0.0 — Alaknanda** — stable evidence contract and operational release baseline.
+
+Release codenames are randomly selected from the configured pool derived from Wikipedia's `Category:Tributaries of the Ganges` and are permanently recorded in release manifests.

--- a/docs/EVIDENCE-CONTRACT.md
+++ b/docs/EVIDENCE-CONTRACT.md
@@ -1,0 +1,39 @@
+# v1 Evidence Contract
+
+UN/CEFACT Portfolio Monitor v1.0 is an evidence and review system. It does not make autonomous trust decisions and does not convert repository activity into assurance conclusions.
+
+## Evidence layers
+
+The v1 contract is intentionally layered. Each layer must preserve the provenance of the layer beneath it.
+
+1. **Portfolio inventory — `portfolio.json`**  
+   Observable public GitLab project metadata discovered from the configured UN/CEFACT namespace.
+2. **Observed change — `changes.json`**  
+   Deterministic comparison with the preceding retained portfolio observation. Structural change and activity-only advancement are separate.
+3. **Declared internal relationships — `relationships.json`**  
+   Reviewed configuration describing internal dependency/profile relationships. These are declarations, not inferred trust facts.
+4. **Impact candidates — `impacts.json`**  
+   Direct review obligations derived when observed structural change occurs in a declared dependency. An obligation is not a failure.
+5. **Policy-matched findings — `findings.json`**  
+   Stable findings created only when an explicit evidence policy matches a review obligation. Severity is declared policy, not an aggregate score.
+6. **Finding lifecycle — `findings-lifecycle.json`**  
+   Persistent active/resolved state keyed by stable finding ID, preserving first/last observation and history.
+7. **External dependency context — `external-dependencies.json`**  
+   Reviewed declarations of external specifications/protocols that may require attention. v1 does not claim automated external change detection.
+8. **Portfolio report — `weekly-report.md` / `weekly-report.html`**  
+   Human-readable synthesis generated from the evidence layers above.
+
+## Invariants
+
+- Observable evidence and declared governance inputs remain distinguishable.
+- Activity-only advancement cannot become a material finding by itself.
+- `related-to` relationships do not create dependency review obligations.
+- A review obligation is not an incompatibility conclusion.
+- A finding is not automatically an assurance failure or trust decision.
+- Resolved findings remain retained as history.
+- No aggregate portfolio score is authoritative in v1.
+- Every generated conclusion must be traceable to inspectable evidence and/or reviewed configuration.
+
+## Stable extension points
+
+Future releases may add role-aware repository-health checks, semantic/schema drift analysis, external-source change polling, additional evidence providers, and multi-hop impact analysis. Such providers must enter through explicit evidence contracts and must not silently weaken the invariants above.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,70 @@
+# Operator Guide
+
+## Normal operation
+
+The monitor runs weekly on GitHub Actions and can also be triggered manually through the `Portfolio scan and Pages` workflow.
+
+Each successful observation performs the same pipeline:
+
+```text
+Discover portfolio
+  → compare with retained baseline
+  → publish internal relationships
+  → derive direct review obligations
+  → evaluate declared finding policies
+  → publish external dependency context
+  → update finding lifecycle
+  → generate weekly report
+  → retain state/evidence
+  → deploy GitHub Pages
+```
+
+## Local run
+
+Python 3.11 or newer is required.
+
+```bash
+python scripts/discover_portfolio.py
+python scripts/compare_snapshots.py
+python scripts/build_site.py
+python scripts/build_relationships.py
+python scripts/build_impacts.py
+python scripts/build_findings.py
+python scripts/build_external_dependencies.py
+python scripts/build_lifecycle_report.py
+```
+
+A first local run has no retained baseline, so change comparison reports baseline establishment rather than treating the whole namespace as newly added.
+
+## What to review first
+
+1. `weekly-report.html` for the human-readable portfolio summary.
+2. `findings.html` for current policy-matched findings.
+3. `impacts.html` for direct review obligations that have not necessarily become findings.
+4. `relationships.html` to inspect the declared internal dependency graph.
+5. `external-dependencies.html` for declared external review context.
+6. JSON evidence when investigating why a finding or obligation exists.
+
+## Disposition model
+
+The monitor currently derives active/resolved lifecycle state from whether a stable finding ID remains present in the current evidence. Human disposition beyond that evidence lifecycle — for example accepted risk, specification correction, false-positive policy adjustment, or governance decision — should be recorded through project workflow rather than inferred by the monitor.
+
+## Release operation
+
+Substantive development follows:
+
+`Issue → branch → PR → CI → merge → release manifest → GitHub Actions release`
+
+Release manifests are validated in CI. A merge to `main` containing a new valid manifest causes the release workflow to create the tag and GitHub Release automatically.
+
+## Failure handling
+
+- **Discovery/API failure:** do not advance the retained portfolio baseline.
+- **Relationship/config validation failure:** treat as monitor configuration failure; do not publish a partial portfolio graph.
+- **Policy validation failure:** do not publish findings from an invalid policy set.
+- **Pages failure after evidence build:** evidence artifacts remain useful, but the publication surface is stale until deployment succeeds.
+- **State-cache miss:** lifecycle/change processing falls back to first-observation semantics rather than inventing history.
+
+## v1 limitations
+
+v1.0 does not automatically poll external standards for semantic changes, score repository health, infer normative compatibility, or make trust decisions. Those remain future extension points under the evidence contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "0.9.0"
+version = "1.0.0"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v1.0.0.yaml
+++ b/releases/v1.0.0.yaml
@@ -1,0 +1,5 @@
+version: v1.0.0
+codename: Alaknanda
+status: release
+summary: Stable v1 portfolio assurance evidence contract, operator guidance, lifecycle reporting baseline, and CI-enforced release readiness.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_PATHS = [
+    "README.md",
+    "docs/EVIDENCE-CONTRACT.md",
+    "docs/OPERATIONS.md",
+    "config/portfolio.toml",
+    "config/relationships.toml",
+    "config/finding-policies.toml",
+    "config/external-dependencies.toml",
+    "scripts/discover_portfolio.py",
+    "scripts/compare_snapshots.py",
+    "scripts/build_site.py",
+    "scripts/build_relationships.py",
+    "scripts/build_impacts.py",
+    "scripts/build_findings.py",
+    "scripts/build_external_dependencies.py",
+    "scripts/build_lifecycle_report.py",
+    ".github/workflows/ci.yml",
+    ".github/workflows/portfolio-scan.yml",
+    ".github/workflows/release.yml",
+    "releases/v1.0.0.yaml",
+]
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    for rel in REQUIRED_PATHS:
+        if not (root / rel).exists():
+            errors.append(f"missing required v1 path: {rel}")
+
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    if pyproject.get("project", {}).get("version") != "1.0.0":
+        errors.append("pyproject version must be 1.0.0 for v1 readiness")
+
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    for phrase in ("Evidence contract", "Operator guide", "v1.0"):
+        if phrase not in readme:
+            errors.append(f"README missing v1 navigation phrase: {phrase}")
+
+    scan = (root / ".github/workflows/portfolio-scan.yml").read_text(encoding="utf-8")
+    for script in ("build_findings.py", "build_external_dependencies.py", "build_lifecycle_report.py"):
+        if script not in scan:
+            errors.append(f"portfolio workflow does not invoke {script}")
+
+    ci = (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    if "release_readiness.py" not in ci:
+        errors.append("CI does not enforce release_readiness.py")
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"readiness error: {error}", file=sys.stderr)
+        return 2
+    print("v1 release readiness: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #21.

Stabilizes the v1 operating contract rather than adding another inference layer:
- documents the eight evidence/reporting layers and invariants
- adds an operator guide and refreshed v1 README
- defines explicit v1 limitations and future extension points
- adds CI-enforced release readiness for required docs, configs, scripts, workflows, version alignment, and scan-stage coverage
- prepares `v1.0.0 — Alaknanda`

The v1 boundary remains evidence-first: no opaque portfolio score and no automatic incompatibility, assurance, or trust conclusion.