### PR TITLE
release: publish v1.0.1 Assi portfolio dashboard

### DIFF
--- a/.github/workflows/portfolio-scan.yml
+++ b/.github/workflows/portfolio-scan.yml
@@ -35,8 +35,6 @@ jobs:
         run: python scripts/discover_portfolio.py
       - name: Compare with previous observation
         run: python scripts/compare_snapshots.py
-      - name: Build portfolio site
-        run: python scripts/build_site.py
       - name: Validate and publish relationships
         run: python scripts/build_relationships.py
       - name: Derive portfolio review obligations
@@ -47,6 +45,8 @@ jobs:
         run: python scripts/build_external_dependencies.py
       - name: Update findings lifecycle and weekly report
         run: python scripts/build_lifecycle_report.py
+      - name: Build portfolio assurance dashboard
+        run: python scripts/build_site.py
       - name: Advance persistent state
         run: |
           mkdir -p .state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "1.0.0"
+version = "1.0.1"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v1.0.1.yaml
+++ b/releases/v1.0.1.yaml
@@ -1,0 +1,5 @@
+version: v1.0.1
+codename: Assi
+status: release
+summary: Portfolio assurance dashboard and navigation over the existing v1 evidence layers.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -24,7 +24,11 @@ def _read(path: Path, default: dict) -> dict:
     return json.loads(path.read_text(encoding="utf-8")) if path.exists() else default
 
 
-def render(snapshot: dict, changes: dict, impacts: dict, lifecycle: dict, external: dict) -> str:
+def render(snapshot: dict, changes: dict | None = None, impacts: dict | None = None, lifecycle: dict | None = None, external: dict | None = None) -> str:
+    changes = changes or {"summary": {}}
+    impacts = impacts or {"summary": {}}
+    lifecycle = lifecycle or {"summary": {}}
+    external = external or {"dependency_count": 0}
     projects = snapshot.get("projects", [])
     generated_at = snapshot.get("generated_at", "unknown")
     source = snapshot.get("source", {})

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -15,94 +15,78 @@ def fmt_date(value: str | None) -> str:
         return "Unknown"
     try:
         dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        return dt.strftime("%Y-%m-%d")
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
     except ValueError:
         return value
 
 
-def render(snapshot: dict, changes: dict | None = None) -> str:
+def _read(path: Path, default: dict) -> dict:
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else default
+
+
+def render(snapshot: dict, changes: dict, impacts: dict, lifecycle: dict, external: dict) -> str:
     projects = snapshot.get("projects", [])
     generated_at = snapshot.get("generated_at", "unknown")
     source = snapshot.get("source", {})
+    change_summary = changes.get("summary", {})
+    lifecycle_summary = lifecycle.get("summary", {})
+    structural = int(change_summary.get("added", 0)) + int(change_summary.get("removed", 0)) + int(change_summary.get("changed", 0))
+    obligations = int(impacts.get("summary", {}).get("review_obligations", 0))
+    active_findings = int(lifecycle_summary.get("active", 0))
+    resolved_findings = int(lifecycle_summary.get("resolved", 0))
+    external_count = int(external.get("dependency_count", 0))
+
     rows = []
     for project in projects:
         topics = ", ".join(project.get("topics") or [])
-        search_blob = " ".join([
-            project.get("name") or "",
-            project.get("path_with_namespace") or "",
-            project.get("description") or "",
-            topics,
-        ]).lower()
+        search_blob = " ".join([project.get("name") or "", project.get("path_with_namespace") or "", project.get("description") or "", topics]).lower()
         state = "Archived" if project.get("archived") else "Active"
         rows.append(f'''<tr data-search="{escape(search_blob, quote=True)}" data-state="{state.lower()}">
 <td><a href="{escape(project.get('web_url') or '#', quote=True)}">{escape(project.get('name') or 'Unnamed')}</a><div class="path">{escape(project.get('path_with_namespace') or '')}</div></td>
-<td>{escape(project.get('default_branch') or '—')}</td>
-<td>{state}</td>
-<td>{escape(fmt_date(project.get('last_activity_at')))}</td>
-<td>{escape(topics or '—')}</td>
-</tr>''')
+<td>{escape(project.get('default_branch') or '—')}</td><td>{state}</td><td>{escape(fmt_date(project.get('last_activity_at')))}</td><td>{escape(topics or '—')}</td></tr>''')
 
-    change_html = ""
-    change_stat = ""
-    if changes:
-        summary = changes.get("summary", {})
-        total_structural = int(summary.get("added", 0)) + int(summary.get("removed", 0)) + int(summary.get("changed", 0))
-        baseline = changes.get("baseline", "unknown")
-        change_stat = f'''<div class="stat"><span>Structural changes</span><strong>{total_structural}</strong><small>Since previous observation</small></div>'''
-        change_html = f'''<div class="note"><strong>Latest observed change:</strong> {summary.get('added',0)} added, {summary.get('removed',0)} removed, {summary.get('changed',0)} metadata-changed, {summary.get('activity_advanced',0)} with activity advancement. Baseline: {escape(str(baseline))}. <a href="changes.json">Inspect changes.json</a>.</div>'''
+    nav = [
+        ("changes.json", "Changes", f"{structural} structural change(s)", "Observed snapshot-to-snapshot differences."),
+        ("relationships.html", "Relationships", "Declared graph", "Portfolio dependency and profile relationships."),
+        ("impacts.html", "Impact review", f"{obligations} obligation(s)", "Direct review obligations derived from changes plus relationships."),
+        ("findings.html", "Findings", f"{active_findings} active", "Current policy-matched findings requiring tracked disposition."),
+        ("external-dependencies.html", "External dependencies", f"{external_count} declared", "Standards and protocol context declared by portfolio projects."),
+        ("weekly-report.html", "Weekly report", f"{resolved_findings} resolved retained", "Lifecycle-aware human-readable portfolio assurance report."),
+    ]
+    cards = "".join(f'''<a class="layer" href="{href}"><strong>{escape(title)}</strong><span>{escape(metric)}</span><small>{escape(desc)}</small></a>''' for href, title, metric, desc in nav)
 
-    return f'''<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>UN/CEFACT Portfolio Monitor</title>
-<style>
-:root{{color-scheme:light dark;--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}
-@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff}}}}
-*{{box-sizing:border-box}} body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}} a{{color:var(--accent);text-decoration:none}} a:hover{{text-decoration:underline}}
-main{{max-width:1240px;margin:auto;padding:40px 24px 72px}} h1{{font-size:34px;margin:0 0 8px}} .lede{{color:var(--muted);max-width:800px;margin:0 0 28px}}
-.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:24px 0}} .stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px}} .stat strong{{display:block;font-size:25px}} .stat small{{display:block;color:var(--muted);margin-top:3px}}
-.controls{{display:flex;gap:10px;flex-wrap:wrap;margin:24px 0}} input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}} input{{min-width:min(100%,360px);flex:1}}
-.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}} table{{width:100%;border-collapse:collapse;min-width:900px}} th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}} th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}} tr:last-child td{{border-bottom:0}} .path{{font-size:12px;color:var(--muted);margin-top:3px}} footer{{color:var(--muted);font-size:13px;margin-top:28px}} code{{font-size:12px}} .note{{border-left:3px solid var(--accent);padding:10px 14px;background:var(--panel);margin:24px 0}}
-</style>
-</head>
-<body><main>
-<h1>UN/CEFACT Portfolio Monitor</h1>
-<p class="lede">Live discovery of public projects in the UN/CEFACT GitLab namespace. This page reports observable repository metadata and changes only; it does not assign health, impact, or assurance conclusions.</p>
-<div class="stats">
-<div class="stat"><span>Discovered projects</span><strong>{len(projects)}</strong></div>
-<div class="stat"><span>Source</span><strong>GitLab</strong><small>{escape(source.get('group',''))}</small></div>
-<div class="stat"><span>Observed</span><strong>{escape(fmt_date(generated_at))}</strong><small>UTC snapshot</small></div>
-{change_stat}
-</div>
-<div class="note">The exact normalized evidence used to generate this view is available as <a href="portfolio.json">portfolio.json</a>.</div>
-{change_html}
-<div class="controls"><input id="q" type="search" placeholder="Search projects, paths, descriptions or topics…" aria-label="Search portfolio"><select id="state"><option value="all">All states</option><option value="active">Active</option><option value="archived">Archived</option></select></div>
-<div class="table-wrap"><table><thead><tr><th>Project</th><th>Default branch</th><th>State</th><th>Last activity</th><th>Topics</th></tr></thead><tbody id="rows">{''.join(rows)}</tbody></table></div>
-<footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Portfolio inventory and change data are observational evidence, not assurance scores.</footer>
-</main>
-<script>
-const q=document.getElementById('q'), state=document.getElementById('state');
-function filter(){{const text=q.value.trim().toLowerCase(), s=state.value;document.querySelectorAll('#rows tr').forEach(row=>{{const matchesText=!text||row.dataset.search.includes(text);const matchesState=s==='all'||row.dataset.state===s;row.hidden=!(matchesText&&matchesState);}})}}
-q.addEventListener('input',filter);state.addEventListener('change',filter);
-</script></body></html>'''
+    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Monitor</title><style>
+:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef;--soft:#eef4ff}}@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff;--soft:#172338}}}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}main{{max-width:1240px;margin:auto;padding:40px 24px 72px}}h1{{font-size:36px;margin:0 0 8px}}h2{{margin-top:36px}}.lede{{color:var(--muted);max-width:880px;margin:0 0 20px}}.boundary{{border-left:3px solid var(--accent);padding:11px 14px;background:var(--panel);margin:20px 0 28px}}.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin:20px 0}}.stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px}}.stat strong{{display:block;font-size:26px}}.stat small{{display:block;color:var(--muted);margin-top:3px}}.layers{{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px;margin:18px 0 30px}}.layer{{display:block;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px;color:var(--text)}}.layer:hover{{border-color:var(--accent);text-decoration:none}}.layer strong,.layer span,.layer small{{display:block}}.layer span{{font-size:20px;margin:5px 0}}.layer small{{color:var(--muted)}}.controls{{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0}}input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}}input{{min-width:min(100%,360px);flex:1}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}}table{{width:100%;border-collapse:collapse;min-width:900px}}th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}.path{{font-size:12px;color:var(--muted);margin-top:3px}}footer{{color:var(--muted);font-size:13px;margin-top:28px}}code{{font-size:12px}}
+</style></head><body><main>
+<h1>UN/CEFACT Portfolio Monitor</h1><p class="lede">Evidence-driven view of the public UN/CEFACT open-source portfolio. The dashboard connects inventory, observed change, declared relationships, review obligations, policy-matched findings, lifecycle state, and external dependency context.</p>
+<div class="boundary"><strong>Interpretation boundary:</strong> these counts summarize inspectable evidence. They are not an aggregate assurance score and do not by themselves establish incompatibility, assurance failure, or a trust decision.</div>
+<div class="stats"><div class="stat"><span>Projects</span><strong>{len(projects)}</strong><small>Current discovery</small></div><div class="stat"><span>Structural changes</span><strong>{structural}</strong><small>Since previous observation</small></div><div class="stat"><span>Review obligations</span><strong>{obligations}</strong><small>Direct relationship-aware review</small></div><div class="stat"><span>Active findings</span><strong>{active_findings}</strong><small>Policy matched</small></div><div class="stat"><span>External dependencies</span><strong>{external_count}</strong><small>Declared context</small></div><div class="stat"><span>Observed</span><strong>{escape(fmt_date(generated_at))}</strong><small>Latest snapshot</small></div></div>
+<h2>Evidence layers</h2><div class="layers">{cards}</div>
+<h2>Portfolio inventory</h2><p class="lede">Search the current discovery below. Exact normalized discovery evidence is available as <a href="portfolio.json">portfolio.json</a>.</p><div class="controls"><input id="q" type="search" placeholder="Search projects, paths, descriptions or topics…" aria-label="Search portfolio"><select id="state"><option value="all">All states</option><option value="active">Active</option><option value="archived">Archived</option></select></div><div class="table-wrap"><table><thead><tr><th>Project</th><th>Default branch</th><th>State</th><th>Last activity</th><th>Topics</th></tr></thead><tbody id="rows">{''.join(rows)}</tbody></table></div>
+<footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Follow the linked evidence layers for interpretation and disposition.</footer></main><script>const q=document.getElementById('q'),state=document.getElementById('state');function filter(){{const text=q.value.trim().toLowerCase(),s=state.value;document.querySelectorAll('#rows tr').forEach(row=>{{row.hidden=!((!text||row.dataset.search.includes(text))&&(s==='all'||row.dataset.state===s));}})}}q.addEventListener('input',filter);state.addEventListener('change',filter);</script></body></html>'''
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Build the static portfolio site from normalized evidence")
+    parser = argparse.ArgumentParser(description="Build the static v1 portfolio assurance dashboard")
     parser.add_argument("--input", type=Path, default=ROOT / "reports" / "latest" / "portfolio.json")
     parser.add_argument("--changes", type=Path, default=ROOT / "reports" / "latest" / "changes.json")
+    parser.add_argument("--impacts", type=Path, default=ROOT / "site" / "impacts.json")
+    parser.add_argument("--lifecycle", type=Path, default=ROOT / "site" / "findings-lifecycle.json")
+    parser.add_argument("--external", type=Path, default=ROOT / "site" / "external-dependencies.json")
     parser.add_argument("--output-dir", type=Path, default=ROOT / "site")
     args = parser.parse_args()
-    snapshot = json.loads(args.input.read_text(encoding="utf-8"))
-    changes = json.loads(args.changes.read_text(encoding="utf-8")) if args.changes.exists() else None
+    snapshot = _read(args.input, {})
+    changes = _read(args.changes, {"summary": {}})
+    impacts = _read(args.impacts, {"summary": {}})
+    lifecycle = _read(args.lifecycle, {"summary": {}})
+    external = _read(args.external, {"dependency_count": 0})
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    (args.output_dir / "index.html").write_text(render(snapshot, changes), encoding="utf-8")
+    (args.output_dir / "index.html").write_text(render(snapshot, changes, impacts, lifecycle, external), encoding="utf-8")
     (args.output_dir / "portfolio.json").write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    if changes:
-        (args.output_dir / "changes.json").write_text(json.dumps(changes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(f"built site with {snapshot.get('project_count', len(snapshot.get('projects', [])))} projects -> {args.output_dir}")
+    (args.output_dir / "changes.json").write_text(json.dumps(changes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"built dashboard with {snapshot.get('project_count', len(snapshot.get('projects', [])))} projects -> {args.output_dir}")
     return 0
 
 

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -36,8 +36,9 @@ def validate(root: Path = ROOT) -> list[str]:
             errors.append(f"missing required v1 path: {rel}")
 
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    if pyproject.get("project", {}).get("version") != "1.0.0":
-        errors.append("pyproject version must be 1.0.0 for v1 readiness")
+    version = str(pyproject.get("project", {}).get("version", ""))
+    if not version.startswith("1."):
+        errors.append("pyproject version must remain on the stable 1.x line for v1 readiness")
 
     readme = (root / "README.md").read_text(encoding="utf-8")
     for phrase in ("Evidence contract", "Operator guide", "v1.0"):
@@ -45,7 +46,7 @@ def validate(root: Path = ROOT) -> list[str]:
             errors.append(f"README missing v1 navigation phrase: {phrase}")
 
     scan = (root / ".github/workflows/portfolio-scan.yml").read_text(encoding="utf-8")
-    for script in ("build_findings.py", "build_external_dependencies.py", "build_lifecycle_report.py"):
+    for script in ("build_findings.py", "build_external_dependencies.py", "build_lifecycle_report.py", "build_site.py"):
         if script not in scan:
             errors.append(f"portfolio workflow does not invoke {script}")
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("build_site", ROOT / "scripts" / "build_site.py")
+build_site = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_site)
+
+
+class DashboardTests(unittest.TestCase):
+    def test_dashboard_surfaces_v1_evidence_layers(self):
+        snapshot = {
+            "generated_at": "2026-08-25T05:00:00Z",
+            "source": {"base_url": "https://example.test", "group": "un/unece/uncefact"},
+            "projects": [{"name": "Spec", "path_with_namespace": "un/unece/uncefact/spec", "web_url": "https://example.test/spec", "default_branch": "main", "archived": False, "last_activity_at": "2026-08-25T04:00:00Z", "topics": []}],
+        }
+        changes = {"summary": {"added": 1, "removed": 0, "changed": 2}}
+        impacts = {"summary": {"review_obligations": 3}}
+        lifecycle = {"summary": {"active": 4, "resolved": 5}}
+        external = {"dependency_count": 6}
+        html = build_site.render(snapshot, changes, impacts, lifecycle, external)
+        self.assertIn("Structural changes</span><strong>3", html)
+        self.assertIn("Review obligations</span><strong>3", html)
+        self.assertIn("Active findings</span><strong>4", html)
+        self.assertIn("External dependencies</span><strong>6", html)
+        for href in ["changes.json", "relationships.html", "impacts.html", "findings.html", "external-dependencies.html", "weekly-report.html"]:
+            self.assertIn(f'href="{href}"', html)
+        self.assertIn("not an aggregate assurance score", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -29,7 +29,7 @@ class SiteTests(unittest.TestCase):
         self.assertIn("Example", html)
         self.assertIn("un/unece/uncefact/example", html)
         self.assertIn("portfolio.json", html)
-        self.assertIn("observational evidence", html.lower())
+        self.assertIn("not an aggregate assurance score", html.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #26.

Transforms the GitHub Pages landing page from a project inventory into a portfolio assurance dashboard over the existing v1 evidence model. Surfaces current projects, structural changes, direct review obligations, active findings, external dependencies, observation time, and clear navigation into Changes, Relationships, Impacts, Findings, External Dependencies, and Weekly Report.

Also moves dashboard generation to the end of the evidence pipeline so the home page is rendered from the exact outputs produced by that run, and adds deterministic dashboard rendering tests.

No new finding, severity, impact, or assurance semantics are introduced.

Release: `v1.0.1 — Assi`.