### PR TITLE
release: publish v1.0.2 Atrai dashboard provenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncefact-portfolio-monitor"
-version = "1.0.1"
+version = "1.0.2"
 description = "Evidence-driven monitoring of the UN/CEFACT open-source portfolio"
 requires-python = ">=3.11"
 

--- a/releases/v1.0.2.yaml
+++ b/releases/v1.0.2.yaml
@@ -1,0 +1,5 @@
+version: v1.0.2
+codename: Atrai
+status: release
+summary: Corrected dashboard release provenance from the merged v1 evidence-dashboard baseline.
+source: https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges


### PR DESCRIPTION
Closes #28.

Provenance-correction patch only. No dashboard, findings, impact, relationship, or assurance semantics change from the merged v1.0.1 dashboard implementation.

Publishes the dashboard from the actual merged baseline as `v1.0.2 — Atrai` rather than rewriting the prematurely created v1.0.1 tag.