### PR TITLE
fix(site): render portfolio relationship graph with Mermaid

### DIFF
--- a/scripts/build_relationships.py
+++ b/scripts/build_relationships.py
@@ -14,6 +14,9 @@ sys.path.insert(0, str(ROOT / "src"))
 from uncefact_portfolio_monitor.relationships import mermaid_graph, validate_relationships
 
 
+MERMAID_VERSION = "11.4.1"
+
+
 def render(data: dict, mermaid: str) -> str:
     rows = []
     for rel in data.get("relationships", []):
@@ -28,12 +31,29 @@ def render(data: dict, mermaid: str) -> str:
     return f'''<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>UN/CEFACT Portfolio Relationships</title>
-<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code,pre{{font-family:ui-monospace,SFMono-Regular,monospace}}pre{{overflow:auto;background:#f5f7fa;padding:16px;border-radius:8px}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
+<style>
+:root{{--bg:#fff;--panel:#f5f7fa;--text:#18202a;--muted:#667085;--line:#ddd;--accent:#155eef}}
+@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff}}}}
+*{{box-sizing:border-box}}body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:var(--text);background:var(--bg)}}a{{color:var(--accent)}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code,pre{{font-family:ui-monospace,SFMono-Regular,monospace}}pre{{overflow:auto;background:var(--panel);padding:16px;border-radius:8px}}.note{{border-left:3px solid var(--accent);padding:10px 14px;background:var(--panel)}}.graph{{margin:24px 0;padding:20px;border:1px solid var(--line);border-radius:10px;overflow:auto;background:var(--bg)}}.mermaid{{min-width:640px;text-align:center}}.render-error{{display:none;color:#b42318;background:#fef3f2;border:1px solid #fecdca;border-radius:8px;padding:12px;margin-top:12px}}details{{margin-top:28px}}summary{{cursor:pointer;font-weight:600;color:var(--accent)}}.lede{{color:var(--muted)}}
+</style></head>
 <body><p><a href="index.html">← Portfolio</a></p><h1>Declared portfolio relationships</h1>
-<p>This view publishes manually reviewed relationship declarations over the discovered portfolio. These declarations are governance inputs, not facts inferred from repository activity and not statements of trust or authority.</p>
+<p class="lede">This view publishes manually reviewed relationship declarations over the discovered portfolio. These declarations are governance inputs, not facts inferred from repository activity and not statements of trust or authority.</p>
 <div class="note">Machine-readable evidence: <a href="relationships.json">relationships.json</a> · Mermaid source: <a href="relationships.mmd">relationships.mmd</a></div>
+<h2>Relationship graph</h2>
+<div class="graph" aria-label="Declared portfolio relationship graph"><pre class="mermaid">{escape(mermaid)}</pre><div id="mermaid-error" class="render-error" role="alert">The relationship graph could not be rendered in this browser. Use the relationship table below or inspect <a href="relationships.mmd">relationships.mmd</a>.</div></div>
+<h2>Declared relationships</h2>
 <table><thead><tr><th>From</th><th>Relationship</th><th>To</th><th>Note</th></tr></thead><tbody>{''.join(rows)}</tbody></table>
-<h2>Mermaid graph source</h2><pre>{escape(mermaid)}</pre>
+<details><summary>View Mermaid graph source</summary><pre>{escape(mermaid)}</pre></details>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@{MERMAID_VERSION}/dist/mermaid.esm.min.mjs';
+try {{
+  mermaid.initialize({{startOnLoad: false, securityLevel: 'strict', theme: 'default'}});
+  await mermaid.run({{querySelector: '.mermaid'}});
+}} catch (error) {{
+  console.error('Mermaid relationship graph failed to render', error);
+  document.getElementById('mermaid-error').style.display = 'block';
+}}
+</script>
 </body></html>'''
 
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -4,7 +4,9 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "scripts"))
 
+from build_relationships import MERMAID_VERSION, render
 from uncefact_portfolio_monitor.relationships import mermaid_graph, validate_relationships
 
 
@@ -26,6 +28,26 @@ class RelationshipTests(unittest.TestCase):
         self.assertEqual(data["relationship_count"], 1)
         self.assertEqual(data["relationships"][0]["provenance"], "declared")
         self.assertIn("profile of", mermaid_graph(data))
+
+    def test_relationship_page_renders_mermaid_and_preserves_fallbacks(self):
+        data = {
+            "relationships": [{
+                "from": "un/unece/uncefact/profile",
+                "to": "un/unece/uncefact/core",
+                "type": "profile-of",
+                "note": "Test declaration",
+            }]
+        }
+        source = "graph TD\n  profile -->|profile of| core\n"
+        html = render(data, source)
+
+        self.assertIn('<pre class="mermaid">', html)
+        self.assertIn(f"mermaid@{MERMAID_VERSION}", html)
+        self.assertIn("await mermaid.run", html)
+        self.assertIn("relationships.mmd", html)
+        self.assertIn("Declared relationships", html)
+        self.assertIn("mermaid-error", html)
+        self.assertNotIn('<h2>Mermaid graph source</h2>', html)
 
     def test_unknown_internal_endpoint_fails(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

Render the declared portfolio relationship graph on `relationships.html` instead of publishing only escaped Mermaid source.

## Changes

- add an actual Mermaid rendering container to the generated relationship page
- load a pinned Mermaid ESM build (`11.4.1`) for deterministic GitHub Pages rendering
- preserve the relationship table and machine-readable `relationships.json` / `relationships.mmd` evidence
- move raw Mermaid source into a collapsible details section
- add an explicit browser-side rendering failure fallback
- extend `tests/test_relationships.py` to enforce the rendering contract

## Assurance / validation

The relationship table remains authoritative human-readable evidence; the diagram is a visualization of the same declared relationship data. The regression test verifies the Mermaid container, pinned runtime, execution hook, evidence links, and fallback state are emitted by the generator.

## Commit metadata

- `fix(site): render portfolio relationship graph with Mermaid`
- `test(site): enforce Mermaid relationship rendering contract`
