### PR TITLE
feat(release): harden tributary codename governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           python-version: '3.11'
       - name: Run unit tests
         run: python -m unittest discover -s tests -v
+      - name: Validate release codename governance
+        run: python scripts/release_codenames.py validate
       - name: Validate release manifests
         run: |
           for manifest in releases/v*.yaml; do

--- a/config/release-codename-policy.json
+++ b/config/release-codename-policy.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "minimumPoolSize": 20,
+  "pool": "config/release-codenames.txt",
+  "source": {
+    "name": "Tributaries of the Ganges",
+    "url": "https://en.wikipedia.org/wiki/Category:Tributaries_of_the_Ganges",
+    "reviewed": "2026-08-30",
+    "selectionBasis": "Repository-maintained reviewed tributary-name pool"
+  },
+  "identity": {
+    "authoritative": "semantic version/tag",
+    "codenameRole": "human-readable release metadata",
+    "persistenceSurface": "releases/vX.Y.Z.yaml"
+  },
+  "selection": {
+    "preferUnused": true,
+    "allowReuseAfterExhaustion": false,
+    "persistBeforeAcceptance": true,
+    "liveSourceFetchAtRelease": false
+  }
+}

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -1,0 +1,58 @@
+# Release codename governance
+
+The UN/CEFACT Portfolio Monitor uses tributary names from a reviewed repository-local pool as human-readable release codenames. Semantic version tags remain the authoritative release identity.
+
+This repository is the **reference implementation pattern** for the cross-repository codename approach. It does not acquire release authority over any adopting repository.
+
+## Provenance and state
+
+- `config/release-codenames.txt` — reviewed eligible tributary names.
+- `config/release-codename-policy.json` — machine-readable source provenance and selection rules.
+- `releases/vX.Y.Z.yaml` — persisted release candidate/release identity, including the selected codename.
+- `scripts/release_codenames.py` — validates the pool and all persisted release bindings and selects an unused future name.
+- `scripts/release_from_manifest.py` — validates a merged release manifest before Actions creates the tag and GitHub Release.
+
+The provenance source is Wikipedia's **Category: Tributaries of the Ganges**. Wikipedia is not fetched during release execution.
+
+## Lifecycle
+
+```text
+coherent capability boundary
+  ↓
+semantic candidate version
+  ↓
+select unused codename from pinned pool
+  ↓
+persist version + codename in releases/vX.Y.Z.yaml
+  ↓
+review candidate manifest with implementation/evidence
+  ↓
+merge accepted manifest
+  ↓
+Actions validates repository-local codename policy
+  ↓
+annotated tag + GitHub Release
+```
+
+Preview an unused codename with:
+
+```bash
+python scripts/release_codenames.py select --version vX.Y.Z
+```
+
+The selected result becomes authoritative presentation metadata only after it is persisted in the reviewed release manifest.
+
+## Invariants
+
+1. The external Wikipedia source is provenance, never a publication dependency.
+2. Pool entries are unique case-insensitively and source-attributed.
+3. Every persisted release codename must be a member of the pinned pool.
+4. Unused names are preferred while available; reuse is currently forbidden.
+5. The same semantic version always resolves to the already-persisted codename.
+6. Pool exhaustion fails closed unless policy is deliberately revised through review.
+7. Release publication consumes the merged manifest and cannot choose a different codename at runtime.
+8. Existing historical release manifests and GitHub Releases are not rewritten.
+
+## Cross-repository adoption contract
+
+Other repositories may implement the same guarantees with different file layouts and naming sources. The portable contract is the behavior—**pinned pool, provenance, persisted candidate identity, executable validation, idempotent publication**—not this repository's exact paths or its tributary theme.

--- a/scripts/release_codenames.py
+++ b/scripts/release_codenames.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Repository-local release codename policy for the portfolio monitor."""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import secrets
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POOL = ROOT / "config" / "release-codenames.txt"
+POLICY = ROOT / "config" / "release-codename-policy.json"
+RELEASES = ROOT / "releases"
+
+class PolicyError(ValueError):
+    pass
+
+
+def load_pool() -> list[str]:
+    return [line.strip() for line in POOL.read_text(encoding="utf-8").splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def load_policy() -> dict:
+    return json.loads(POLICY.read_text(encoding="utf-8"))
+
+
+def parse_manifest(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition(":")
+        if not sep:
+            raise PolicyError(f"invalid manifest line in {path.name}: {raw}")
+        data[key.strip()] = value.strip()
+    return data
+
+
+def release_bindings() -> list[dict[str, str]]:
+    return [parse_manifest(path) for path in sorted(RELEASES.glob("v*.yaml"))]
+
+
+def validate() -> None:
+    pool = load_pool()
+    policy = load_policy()
+    errors: list[str] = []
+    if policy.get("schemaVersion") != 1:
+        errors.append("policy schemaVersion must be 1")
+    if policy.get("pool") != "config/release-codenames.txt":
+        errors.append("policy must reference config/release-codenames.txt")
+    if len(pool) < int(policy.get("minimumPoolSize", 20)):
+        errors.append("codename pool is below minimumPoolSize")
+    folded = [name.casefold() for name in pool]
+    if len(folded) != len(set(folded)):
+        errors.append("codename pool contains case-insensitive duplicates")
+    if not str(policy.get("source", {}).get("url", "")).startswith("https://"):
+        errors.append("source URL must use https")
+    selection = policy.get("selection", {})
+    if selection.get("liveSourceFetchAtRelease") is not False:
+        errors.append("release-time source fetching must be disabled")
+    if selection.get("persistBeforeAcceptance") is not True:
+        errors.append("codename must be persisted before release acceptance")
+    allowed = {name.casefold() for name in pool}
+    bindings = release_bindings()
+    versions = [item.get("version", "") for item in bindings]
+    if len(versions) != len(set(versions)):
+        errors.append("release manifests contain duplicate semantic versions")
+    used: list[str] = []
+    for item in bindings:
+        codename = item.get("codename", "")
+        if codename.casefold() not in allowed:
+            errors.append(f"release codename is outside pinned pool: {codename!r}")
+        used.append(codename.casefold())
+    if not selection.get("allowReuseAfterExhaustion", False) and len(used) != len(set(used)):
+        errors.append("release manifests reuse a codename while policy forbids reuse")
+    if errors:
+        raise PolicyError("; ".join(errors))
+
+
+def select(version: str, seed: str | None = None) -> tuple[str, bool]:
+    validate()
+    bindings = release_bindings()
+    existing = next((item for item in bindings if item.get("version") == version), None)
+    if existing:
+        return existing["codename"], True
+    pool = load_pool()
+    policy = load_policy()
+    used = {item.get("codename", "").casefold() for item in bindings}
+    candidates = [name for name in pool if name.casefold() not in used]
+    if not candidates:
+        if policy["selection"].get("allowReuseAfterExhaustion", False):
+            candidates = pool
+        else:
+            raise PolicyError("codename pool exhausted and reuse is forbidden")
+    chosen = secrets.choice(candidates) if seed is None else random.Random(seed).choice(candidates)
+    return chosen, False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate")
+    choose = sub.add_parser("select")
+    choose.add_argument("--version", required=True)
+    choose.add_argument("--seed")
+    args = parser.parse_args()
+    if args.command == "validate":
+        validate()
+        print("PASS release codename governance")
+        return 0
+    codename, existing = select(args.version, args.seed)
+    print(json.dumps({"version": args.version, "codename": codename, "existing": existing}))
+    return 0
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PolicyError as exc:
+        print(f"ERROR: {exc}")
+        raise SystemExit(2)

--- a/scripts/release_from_manifest.py
+++ b/scripts/release_from_manifest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import re
 import sys
 
+import release_codenames
+
 ROOT = Path(__file__).resolve().parents[1]
 POOL = ROOT / "config" / "release-codenames.txt"
 VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+$")
@@ -26,6 +28,7 @@ def parse_manifest(path: Path) -> dict[str, str]:
 
 
 def validate(path: Path) -> dict[str, str]:
+    release_codenames.validate()
     data = parse_manifest(path)
     version = data.get("version", "")
     codename = data.get("codename", "")
@@ -34,7 +37,7 @@ def validate(path: Path) -> dict[str, str]:
     expected = f"{version}.yaml"
     if path.name != expected:
         raise ValueError(f"manifest filename must be {expected}")
-    pool = {line.strip() for line in POOL.read_text(encoding="utf-8").splitlines() if line.strip()}
+    pool = {line.strip() for line in POOL.read_text(encoding="utf-8").splitlines() if line.strip() and not line.lstrip().startswith("#")}
     if codename not in pool:
         raise ValueError(f"codename {codename!r} is not in configured tributary pool")
     if data.get("status") != "release":
@@ -49,7 +52,7 @@ def main() -> int:
     args = parser.parse_args()
     try:
         data = validate(args.manifest)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, release_codenames.PolicyError) as exc:
         print(f"release manifest error: {exc}", file=sys.stderr)
         return 2
 

--- a/tests/test_release_codenames.py
+++ b/tests/test_release_codenames.py
@@ -1,0 +1,30 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location("release_codenames", Path(__file__).resolve().parents[1] / "scripts" / "release_codenames.py")
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+class ReleaseCodenameTests(unittest.TestCase):
+    def test_repository_release_governance_is_valid(self):
+        mod.validate()
+
+    def test_existing_manifest_binding_is_idempotent(self):
+        bindings = mod.release_bindings()
+        self.assertTrue(bindings)
+        item = bindings[0]
+        codename, existing = mod.select(item["version"], seed="ignored")
+        self.assertTrue(existing)
+        self.assertEqual(item["codename"], codename)
+
+    def test_future_selection_uses_unused_pool_name(self):
+        used = {item["codename"] for item in mod.release_bindings()}
+        codename, existing = mod.select("v99.99.99", seed="fixed")
+        self.assertFalse(existing)
+        self.assertNotIn(codename, used)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Governing issue

Closes #31.

## Proposition

The existing tributary-based release mechanism should be the explicit cross-repository reference pattern: source provenance and selection policy are machine-readable; the selected name is persisted in the versioned release manifest before merge; CI and publication validate that persisted identity; live Wikipedia state never participates in release execution.

## Changes

- add machine-readable provenance and selection policy;
- add repository-wide codename validator/unused-name selector;
- validate every historical release manifest against the pinned pool and non-reuse policy;
- integrate policy validation into manifest publication and CI;
- add pressure tests for existing-idempotent and future-unused selection;
- document the reference contract while explicitly preserving local repository authority.

## Compatibility

No historical release manifest, tag, or GitHub Release is renamed or rewritten. The existing manifest-driven Actions publication model remains intact.