### PR TITLE
Improve Pages evidence UX and decision detail

### DIFF
--- a/scripts/build_relationships.py
+++ b/scripts/build_relationships.py
@@ -33,7 +33,6 @@ def render(data: dict, mermaid: str) -> str:
 <title>UN/CEFACT Portfolio Relationships</title>
 <style>
 :root{{--bg:#fff;--panel:#f5f7fa;--text:#18202a;--muted:#667085;--line:#ddd;--accent:#155eef}}
-@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff}}}}
 *{{box-sizing:border-box}}body{{font:15px/1.55 system-ui,sans-serif;max-width:1200px;margin:auto;padding:36px 22px;color:var(--text);background:var(--bg)}}a{{color:var(--accent)}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code,pre{{font-family:ui-monospace,SFMono-Regular,monospace}}pre{{overflow:auto;background:var(--panel);padding:16px;border-radius:8px}}.note{{border-left:3px solid var(--accent);padding:10px 14px;background:var(--panel)}}.graph{{margin:24px 0;padding:20px;border:1px solid var(--line);border-radius:10px;overflow:auto;background:var(--bg)}}.mermaid{{min-width:640px;text-align:center}}.render-error{{display:none;color:#b42318;background:#fef3f2;border:1px solid #fecdca;border-radius:8px;padding:12px;margin-top:12px}}details{{margin-top:28px}}summary{{cursor:pointer;font-weight:600;color:var(--accent)}}.lede{{color:var(--muted)}}
 </style></head>
 <body><p><a href="index.html">← Portfolio</a></p><h1>Declared portfolio relationships</h1>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -24,7 +24,62 @@ def _read(path: Path, default: dict) -> dict:
     return json.loads(path.read_text(encoding="utf-8")) if path.exists() else default
 
 
-def render(snapshot: dict, changes: dict | None = None, impacts: dict | None = None, lifecycle: dict | None = None, external: dict | None = None) -> str:
+def _change_detail(changes: dict, limit: int = 8) -> str:
+    items: list[str] = []
+    for item in changes.get("changed", []):
+        fields = ", ".join(sorted((item.get("fields") or {}).keys())) or "metadata"
+        items.append(
+            f"<li><code>{escape(item.get('path_with_namespace') or 'unknown')}</code> — "
+            f"changed {escape(fields)}</li>"
+        )
+        if len(items) >= limit:
+            break
+    for kind, label in (("added", "added to discovery"), ("removed", "removed from discovery")):
+        if len(items) >= limit:
+            break
+        for item in changes.get(kind, []):
+            items.append(
+                f"<li><code>{escape(item.get('path_with_namespace') or 'unknown')}</code> — {label}</li>"
+            )
+            if len(items) >= limit:
+                break
+    return "".join(items) or '<li class="empty">No structural changes in this observation.</li>'
+
+
+def _review_detail(impacts: dict, limit: int = 8) -> str:
+    items: list[str] = []
+    for item in impacts.get("review_obligations", [])[:limit]:
+        reason = item.get("reason") or item.get("relationship_type") or "relationship-aware review"
+        items.append(
+            f"<li><code>{escape(item.get('review_project') or 'unknown')}</code> reviews "
+            f"<code>{escape(item.get('changed_project') or 'unknown')}</code> — {escape(reason)}</li>"
+        )
+    return "".join(items) or '<li class="empty">No direct review obligations in this observation.</li>'
+
+
+def _finding_detail(lifecycle: dict, limit: int = 8) -> str:
+    items: list[str] = []
+    for item in lifecycle.get("records", []):
+        if item.get("status") != "active":
+            continue
+        items.append(
+            f"<li><strong>{escape(str(item.get('severity') or 'unknown').upper())}</strong> "
+            f"<code>{escape(item.get('finding_id') or 'unknown')}</code> — "
+            f"<code>{escape(item.get('subject_project') or 'unknown')}</code> reviewing "
+            f"<code>{escape(item.get('dependency_project') or 'unknown')}</code></li>"
+        )
+        if len(items) >= limit:
+            break
+    return "".join(items) or '<li class="empty">No active lifecycle findings in this observation.</li>'
+
+
+def render(
+    snapshot: dict,
+    changes: dict | None = None,
+    impacts: dict | None = None,
+    lifecycle: dict | None = None,
+    external: dict | None = None,
+) -> str:
     changes = changes or {"summary": {}}
     impacts = impacts or {"summary": {}}
     lifecycle = lifecycle or {"summary": {}}
@@ -34,7 +89,11 @@ def render(snapshot: dict, changes: dict | None = None, impacts: dict | None = N
     source = snapshot.get("source", {})
     change_summary = changes.get("summary", {})
     lifecycle_summary = lifecycle.get("summary", {})
-    structural = int(change_summary.get("added", 0)) + int(change_summary.get("removed", 0)) + int(change_summary.get("changed", 0))
+    structural = (
+        int(change_summary.get("added", 0))
+        + int(change_summary.get("removed", 0))
+        + int(change_summary.get("changed", 0))
+    )
     obligations = int(impacts.get("summary", {}).get("review_obligations", 0))
     active_findings = int(lifecycle_summary.get("active", 0))
     resolved_findings = int(lifecycle_summary.get("resolved", 0))
@@ -43,33 +102,126 @@ def render(snapshot: dict, changes: dict | None = None, impacts: dict | None = N
     rows = []
     for project in projects:
         topics = ", ".join(project.get("topics") or [])
-        search_blob = " ".join([project.get("name") or "", project.get("path_with_namespace") or "", project.get("description") or "", topics]).lower()
+        search_blob = " ".join(
+            [
+                project.get("name") or "",
+                project.get("path_with_namespace") or "",
+                project.get("description") or "",
+                topics,
+            ]
+        ).lower()
         state = "Archived" if project.get("archived") else "Active"
-        rows.append(f'''<tr data-search="{escape(search_blob, quote=True)}" data-state="{state.lower()}">
+        rows.append(
+            f'''<tr data-search="{escape(search_blob, quote=True)}" data-state="{state.lower()}">
 <td><a href="{escape(project.get('web_url') or '#', quote=True)}">{escape(project.get('name') or 'Unnamed')}</a><div class="path">{escape(project.get('path_with_namespace') or '')}</div></td>
-<td>{escape(project.get('default_branch') or '—')}</td><td>{state}</td><td>{escape(fmt_date(project.get('last_activity_at')))}</td><td>{escape(topics or '—')}</td></tr>''')
+<td>{escape(project.get('default_branch') or '—')}</td><td>{state}</td><td>{escape(fmt_date(project.get('last_activity_at')))}</td><td>{escape(topics or '—')}</td></tr>'''
+        )
 
     nav = [
-        ("changes.json", "Changes", f"{structural} structural change(s)", "Observed snapshot-to-snapshot differences."),
+        ("changes.html", "Changes", f"{structural} structural change(s)", "Observed snapshot-to-snapshot differences."),
         ("relationships.html", "Relationships", "Declared graph", "Portfolio dependency and profile relationships."),
         ("impacts.html", "Impact review", f"{obligations} obligation(s)", "Direct review obligations derived from changes plus relationships."),
         ("findings.html", "Findings", f"{active_findings} active", "Current policy-matched findings requiring tracked disposition."),
         ("external-dependencies.html", "External dependencies", f"{external_count} declared", "Standards and protocol context declared by portfolio projects."),
         ("weekly-report.html", "Weekly report", f"{resolved_findings} resolved retained", "Lifecycle-aware human-readable portfolio assurance report."),
     ]
-    cards = "".join(f'''<a class="layer" href="{href}"><strong>{escape(title)}</strong><span>{escape(metric)}</span><small>{escape(desc)}</small></a>''' for href, title, metric, desc in nav)
+    cards = "".join(
+        f'''<a class="layer" href="{href}"><strong>{escape(title)}</strong><span>{escape(metric)}</span><small>{escape(desc)}</small></a>'''
+        for href, title, metric, desc in nav
+    )
+    observation_window = (
+        f"{escape(fmt_date(changes.get('previous_generated_at')))} → "
+        f"{escape(fmt_date(changes.get('current_generated_at') or generated_at))}"
+        if changes.get("previous_generated_at")
+        else f"Current snapshot: {escape(fmt_date(generated_at))}"
+    )
 
     return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>UN/CEFACT Portfolio Monitor</title><style>
-:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef;--soft:#eef4ff}}@media(prefers-color-scheme:dark){{:root{{--bg:#101318;--panel:#171b21;--text:#f4f6f8;--muted:#a9b2bd;--line:#303640;--accent:#84adff;--soft:#172338}}}}
-*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}main{{max-width:1240px;margin:auto;padding:40px 24px 72px}}h1{{font-size:36px;margin:0 0 8px}}h2{{margin-top:36px}}.lede{{color:var(--muted);max-width:880px;margin:0 0 20px}}.boundary{{border-left:3px solid var(--accent);padding:11px 14px;background:var(--panel);margin:20px 0 28px}}.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin:20px 0}}.stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px}}.stat strong{{display:block;font-size:26px}}.stat small{{display:block;color:var(--muted);margin-top:3px}}.layers{{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px;margin:18px 0 30px}}.layer{{display:block;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px;color:var(--text)}}.layer:hover{{border-color:var(--accent);text-decoration:none}}.layer strong,.layer span,.layer small{{display:block}}.layer span{{font-size:20px;margin:5px 0}}.layer small{{color:var(--muted)}}.controls{{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0}}input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}}input{{min-width:min(100%,360px);flex:1}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}}table{{width:100%;border-collapse:collapse;min-width:900px}}th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}.path{{font-size:12px;color:var(--muted);margin-top:3px}}footer{{color:var(--muted);font-size:13px;margin-top:28px}}code{{font-size:12px}}
+:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef;--soft:#eef4ff}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}main{{max-width:1240px;margin:auto;padding:40px 24px 72px}}h1{{font-size:36px;margin:0 0 8px}}h2{{margin-top:36px}}.lede{{color:var(--muted);max-width:920px;margin:0 0 20px}}.boundary{{border-left:3px solid var(--accent);padding:11px 14px;background:var(--panel);margin:20px 0 28px}}.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin:20px 0}}.stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px}}.stat strong{{display:block;font-size:26px}}.stat small{{display:block;color:var(--muted);margin-top:3px}}.layers{{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px;margin:18px 0 30px}}.layer{{display:block;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px;color:var(--text)}}.layer:hover{{border-color:var(--accent);text-decoration:none}}.layer strong,.layer span,.layer small{{display:block}}.layer span{{font-size:20px;margin:5px 0}}.layer small{{color:var(--muted)}}.detail-grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:12px;margin:18px 0}}.detail{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:17px}}.detail h3{{margin:0 0 10px;font-size:17px}}.detail ul{{margin:0;padding-left:20px}}.detail li{{margin:7px 0}}.empty{{color:var(--muted)}}.controls{{display:flex;gap:10px;flex-wrap:wrap;margin:20px 0}}input,select{{font:inherit;padding:10px 12px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--text)}}input{{min-width:min(100%,360px);flex:1}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px}}table{{width:100%;border-collapse:collapse;min-width:900px}}th,td{{text-align:left;padding:13px 14px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}.path{{font-size:12px;color:var(--muted);margin-top:3px}}footer{{color:var(--muted);font-size:13px;margin-top:28px}}code{{font-size:12px}}
 </style></head><body><main>
 <h1>UN/CEFACT Portfolio Monitor</h1><p class="lede">Evidence-driven view of the public UN/CEFACT open-source portfolio. The dashboard connects inventory, observed change, declared relationships, review obligations, policy-matched findings, lifecycle state, and external dependency context.</p>
 <div class="boundary"><strong>Interpretation boundary:</strong> these counts summarize inspectable evidence. They are not an aggregate assurance score and do not by themselves establish incompatibility, assurance failure, or a trust decision.</div>
 <div class="stats"><div class="stat"><span>Projects</span><strong>{len(projects)}</strong><small>Current discovery</small></div><div class="stat"><span>Structural changes</span><strong>{structural}</strong><small>Since previous observation</small></div><div class="stat"><span>Review obligations</span><strong>{obligations}</strong><small>Direct relationship-aware review</small></div><div class="stat"><span>Active findings</span><strong>{active_findings}</strong><small>Policy matched</small></div><div class="stat"><span>External dependencies</span><strong>{external_count}</strong><small>Declared context</small></div><div class="stat"><span>Observed</span><strong>{escape(fmt_date(generated_at))}</strong><small>Latest snapshot</small></div></div>
 <h2>Evidence layers</h2><div class="layers">{cards}</div>
+<h2>Current observation</h2>
+<p class="lede">Decision-first summary for the latest evidence window: <strong>{observation_window}</strong>. Drill into the linked evidence before drawing compatibility, assurance, or trust conclusions.</p>
+<div class="detail-grid">
+<section class="detail"><h3>What changed</h3><ul>{_change_detail(changes)}</ul><p><a href="changes.html">Inspect all observed changes →</a></p></section>
+<section class="detail"><h3>Direct review queue</h3><ul>{_review_detail(impacts)}</ul><p><a href="impacts.html">Inspect review obligations →</a></p></section>
+<section class="detail"><h3>Active findings</h3><ul>{_finding_detail(lifecycle)}</ul><p><a href="findings.html">Inspect finding evidence →</a></p></section>
+</div>
+<h2>How to read this monitor</h2>
+<p class="lede"><strong>Observed change</strong> is evidence, not a defect. <strong>Review obligations</strong> are relationship-aware prompts for examination. <strong>Findings</strong> are policy-matched evidence conditions requiring tracked disposition. None of these layers is an aggregate trust score.</p>
 <h2>Portfolio inventory</h2><p class="lede">Search the current discovery below. Exact normalized discovery evidence is available as <a href="portfolio.json">portfolio.json</a>.</p><div class="controls"><input id="q" type="search" placeholder="Search projects, paths, descriptions or topics…" aria-label="Search portfolio"><select id="state"><option value="all">All states</option><option value="active">Active</option><option value="archived">Archived</option></select></div><div class="table-wrap"><table><thead><tr><th>Project</th><th>Default branch</th><th>State</th><th>Last activity</th><th>Topics</th></tr></thead><tbody id="rows">{''.join(rows)}</tbody></table></div>
 <footer>Generated from <code>{escape(source.get('base_url',''))}/{escape(source.get('group',''))}</code> at {escape(generated_at)}. Follow the linked evidence layers for interpretation and disposition.</footer></main><script>const q=document.getElementById('q'),state=document.getElementById('state');function filter(){{const text=q.value.trim().toLowerCase(),s=state.value;document.querySelectorAll('#rows tr').forEach(row=>{{row.hidden=!((!text||row.dataset.search.includes(text))&&(s==='all'||row.dataset.state===s));}})}}q.addEventListener('input',filter);state.addEventListener('change',filter);</script></body></html>'''
+
+
+def render_changes(changes: dict) -> str:
+    summary = changes.get("summary", {})
+    activity_rows = []
+    for item in changes.get("activity_advanced", []):
+        activity_rows.append(
+            "<tr>"
+            f"<td><code>{escape(item.get('path_with_namespace') or 'unknown')}</code></td>"
+            f"<td>{escape(fmt_date(item.get('before')))}</td>"
+            f"<td>{escape(fmt_date(item.get('after')))}</td>"
+            "</tr>"
+        )
+    if not activity_rows:
+        activity_rows.append('<tr><td colspan="3" class="empty">No activity-only advancements.</td></tr>')
+
+    structural_rows = []
+    for kind in ("added", "removed"):
+        for item in changes.get(kind, []):
+            structural_rows.append(
+                "<tr>"
+                f"<td>{escape(kind.title())}</td>"
+                f"<td><code>{escape(item.get('path_with_namespace') or 'unknown')}</code></td>"
+                "<td>—</td><td>—</td>"
+                "</tr>"
+            )
+    for item in changes.get("changed", []):
+        fields = item.get("fields") or {}
+        if not fields:
+            structural_rows.append(
+                "<tr><td>Changed</td>"
+                f"<td><code>{escape(item.get('path_with_namespace') or 'unknown')}</code></td>"
+                "<td>metadata</td><td>Observed value changed</td></tr>"
+            )
+            continue
+        for field, delta in sorted(fields.items()):
+            structural_rows.append(
+                "<tr><td>Changed</td>"
+                f"<td><code>{escape(item.get('path_with_namespace') or 'unknown')}</code></td>"
+                f"<td><code>{escape(field)}</code></td>"
+                f"<td><code>{escape(json.dumps(delta.get('before'), ensure_ascii=False))}</code> → "
+                f"<code>{escape(json.dumps(delta.get('after'), ensure_ascii=False))}</code></td></tr>"
+            )
+    if not structural_rows:
+        structural_rows.append('<tr><td colspan="4" class="empty">No structural changes in this observation.</td></tr>')
+
+    window = (
+        f"{escape(fmt_date(changes.get('previous_generated_at')))} → "
+        f"{escape(fmt_date(changes.get('current_generated_at')))}"
+    )
+    structural = (
+        int(summary.get("added", 0))
+        + int(summary.get("removed", 0))
+        + int(summary.get("changed", 0))
+    )
+    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Changes</title><style>
+:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}main{{max-width:1200px;margin:auto;padding:36px 22px 72px}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}h1{{margin-bottom:8px}}.lede,.empty{{color:var(--muted)}}.note{{border-left:3px solid var(--accent);padding:11px 14px;background:var(--panel);margin:20px 0}}.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:20px 0}}.stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px}}.stat strong{{display:block;font-size:24px}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px;margin:16px 0 28px}}table{{width:100%;border-collapse:collapse;min-width:720px}}th,td{{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}}code{{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12px}}
+</style></head><body><main><p><a href="index.html">← Portfolio</a> · <a href="changes.json">Raw JSON</a></p>
+<h1>Observed portfolio changes</h1><p class="lede">Human-readable snapshot comparison. This page renders the canonical <a href="changes.json">changes.json</a> evidence without changing its machine-readable contract.</p>
+<div class="note"><strong>Observation window:</strong> {window}. Structural change is evidence requiring interpretation; it is not automatically incompatibility or assurance failure.</div>
+<div class="stats"><div class="stat"><span>Structural</span><strong>{structural}</strong></div><div class="stat"><span>Added</span><strong>{summary.get('added',0)}</strong></div><div class="stat"><span>Removed</span><strong>{summary.get('removed',0)}</strong></div><div class="stat"><span>Changed</span><strong>{summary.get('changed',0)}</strong></div><div class="stat"><span>Activity advanced</span><strong>{summary.get('activity_advanced',0)}</strong></div></div>
+<h2>Structural changes</h2><div class="table-wrap"><table><thead><tr><th>Type</th><th>Project</th><th>Field</th><th>Before → after</th></tr></thead><tbody>{''.join(structural_rows)}</tbody></table></div>
+<h2>Activity advancements</h2><p class="lede">Projects whose last-activity timestamp advanced between observations. These are reported separately from structural metadata changes.</p><div class="table-wrap"><table><thead><tr><th>Project</th><th>Previous activity</th><th>Current activity</th></tr></thead><tbody>{''.join(activity_rows)}</tbody></table></div>
+</main></body></html>'''
 
 
 def main() -> int:
@@ -87,10 +239,20 @@ def main() -> int:
     lifecycle = _read(args.lifecycle, {"summary": {}})
     external = _read(args.external, {"dependency_count": 0})
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    (args.output_dir / "index.html").write_text(render(snapshot, changes, impacts, lifecycle, external), encoding="utf-8")
-    (args.output_dir / "portfolio.json").write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    (args.output_dir / "changes.json").write_text(json.dumps(changes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(f"built dashboard with {snapshot.get('project_count', len(snapshot.get('projects', [])))} projects -> {args.output_dir}")
+    (args.output_dir / "index.html").write_text(
+        render(snapshot, changes, impacts, lifecycle, external), encoding="utf-8"
+    )
+    (args.output_dir / "portfolio.json").write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (args.output_dir / "changes.json").write_text(
+        json.dumps(changes, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (args.output_dir / "changes.html").write_text(render_changes(changes), encoding="utf-8")
+    print(
+        f"built dashboard with {snapshot.get('project_count', len(snapshot.get('projects', [])))} "
+        f"projects -> {args.output_dir}"
+    )
     return 0
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -24,9 +24,13 @@ class DashboardTests(unittest.TestCase):
         self.assertIn("Review obligations</span><strong>3", html)
         self.assertIn("Active findings</span><strong>4", html)
         self.assertIn("External dependencies</span><strong>6", html)
-        for href in ["changes.json", "relationships.html", "impacts.html", "findings.html", "external-dependencies.html", "weekly-report.html"]:
+        for href in ["changes.html", "relationships.html", "impacts.html", "findings.html", "external-dependencies.html", "weekly-report.html"]:
             self.assertIn(f'href="{href}"', html)
         self.assertIn("not an aggregate assurance score", html)
+        self.assertIn("Current observation", html)
+        self.assertIn("Direct review queue", html)
+        self.assertIn("How to read this monitor", html)
+        self.assertNotIn("prefers-color-scheme:dark", html)
 
 
 if __name__ == "__main__":

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,6 +1,9 @@
 import importlib.util
+import json
 from pathlib import Path
+import tempfile
 import unittest
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location("build_site", ROOT / "scripts" / "build_site.py")
@@ -30,6 +33,61 @@ class SiteTests(unittest.TestCase):
         self.assertIn("un/unece/uncefact/example", html)
         self.assertIn("portfolio.json", html)
         self.assertIn("not an aggregate assurance score", html.lower())
+        self.assertNotIn("prefers-color-scheme:dark", html)
+
+    def test_render_changes_exposes_human_detail_and_raw_evidence(self):
+        changes = {
+            "previous_generated_at": "2026-08-24T05:00:00Z",
+            "current_generated_at": "2026-08-25T05:00:00Z",
+            "summary": {"added": 0, "removed": 0, "changed": 1, "activity_advanced": 1},
+            "changed": [{
+                "path_with_namespace": "un/unece/uncefact/example",
+                "fields": {"visibility": {"before": None, "after": "public"}},
+            }],
+            "activity_advanced": [{
+                "path_with_namespace": "un/unece/uncefact/example",
+                "before": "2026-08-24T12:00:00Z",
+                "after": "2026-08-25T12:00:00Z",
+            }],
+        }
+        html = build_site.render_changes(changes)
+        self.assertIn("Observed portfolio changes", html)
+        self.assertIn("changes.json", html)
+        self.assertIn("visibility", html)
+        self.assertIn("null", html)
+        self.assertIn("public", html)
+        self.assertIn("Activity advancements", html)
+        self.assertNotIn("prefers-color-scheme:dark", html)
+
+    def test_main_preserves_canonical_changes_json_and_adds_html(self):
+        snapshot = {
+            "generated_at": "2026-08-25T05:00:00Z",
+            "source": {"base_url": "https://example.test", "group": "un/unece/uncefact"},
+            "projects": [],
+        }
+        changes = {
+            "schema_version": "1",
+            "summary": {"added": 0, "removed": 0, "changed": 0, "activity_advanced": 0},
+            "added": [], "removed": [], "changed": [], "activity_advanced": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            portfolio_path = root / "portfolio.json"
+            changes_path = root / "input-changes.json"
+            output = root / "site"
+            portfolio_path.write_text(json.dumps(snapshot), encoding="utf-8")
+            changes_path.write_text(json.dumps(changes), encoding="utf-8")
+            argv = [
+                "build_site.py", "--input", str(portfolio_path), "--changes", str(changes_path),
+                "--impacts", str(root / "missing-impacts.json"),
+                "--lifecycle", str(root / "missing-lifecycle.json"),
+                "--external", str(root / "missing-external.json"),
+                "--output-dir", str(output),
+            ]
+            with patch("sys.argv", argv):
+                self.assertEqual(build_site.main(), 0)
+            self.assertEqual(json.loads((output / "changes.json").read_text(encoding="utf-8")), changes)
+            self.assertIn("Observed portfolio changes", (output / "changes.html").read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #33.

## What changed

- adds a human-readable `changes.html` view with:
  - observation window;
  - structural-change summary;
  - field-level before/after values;
  - activity-only advancements;
  - explicit link back to canonical `changes.json`;
- changes the dashboard **Changes** card to open the rendered evidence view;
- preserves `changes.json` byte-for-byte as JSON output from the same input data;
- expands the landing page into a decision-first view with:
  - current observation window;
  - changed-project detail;
  - direct review queue;
  - active finding detail;
  - explicit interpretation semantics;
- standardizes generated Pages on a light presentation rather than switching automatically with OS dark mode;
- adds regression tests covering the rendered changes view, detailed landing sections, light baseline, and JSON compatibility.

## Architectural choice

The requested UX cannot safely be implemented by serving HTML at the existing `changes.json` path: the v1 evidence contract documents that path as machine-readable JSON, and static GitHub Pages content is extension-addressed. Replacing it would create a compatibility break.

The patch therefore makes the human/machine boundary explicit:

`changes.html` → rendered evidence for people  
`changes.json` → canonical evidence for machines

## Evidence / falsification

The implementation is wrong if:

- the dashboard still sends a human reader directly to raw JSON;
- `changes.json` ceases to parse to the original change document;
- current review/finding detail is absent from the landing page;
- the UI implies that changes/findings are an aggregate assurance or trust score.

CI is expected to exercise the existing suite plus the new regression coverage.