### PR TITLE
Make weekly assurance report tabular and scan-friendly

### DIFF
--- a/scripts/build_lifecycle_report.py
+++ b/scripts/build_lifecycle_report.py
@@ -52,12 +52,81 @@ def _finding_lines(lifecycle: dict, status: str) -> str:
     records = [r for r in lifecycle.get("records", []) if r.get("status") == status]
     if not records:
         return "_None in this observation._"
-    return "\n".join(f"- **{r.get('severity','unknown').upper()}** `{r['finding_id']}` — `{r.get('subject_project')}` reviewing `{r.get('dependency_project')}` ({r.get('relationship_type')}, {r.get('change_type')}); observed {r.get('observation_count',1)} time(s)." for r in records)
+    return "\n".join(
+        f"- **{r.get('severity','unknown').upper()}** `{r['finding_id']}` — "
+        f"`{r.get('subject_project')}` reviewing `{r.get('dependency_project')}` "
+        f"({r.get('relationship_type')}, {r.get('change_type')}); observed "
+        f"{r.get('observation_count',1)} time(s)."
+        for r in records
+    )
 
 
-def html_report(markdown: str, lifecycle: dict) -> str:
-    lines = "".join(f"<p>{escape(line)}</p>" if line and not line.startswith('#') and not line.startswith('- ') else (f"<h2>{escape(line[3:])}</h2>" if line.startswith('## ') else (f"<h1>{escape(line[2:])}</h1>" if line.startswith('# ') else (f"<li>{escape(line[2:])}</li>" if line.startswith('- ') else ""))) for line in markdown.splitlines())
-    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>UN/CEFACT Portfolio Assurance Report</title><style>body{{font:15px/1.6 system-ui,sans-serif;max-width:1000px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head><body><p><a href="index.html">← Portfolio</a> · <a href="findings.html">Current findings</a> · <a href="external-dependencies.html">External dependencies</a></p><div class="note">Machine-readable lifecycle: <a href="findings-lifecycle.json">findings-lifecycle.json</a> · Markdown report: <a href="weekly-report.md">weekly-report.md</a></div>{lines}<p><small>{escape(lifecycle.get('assurance_boundary',''))}</small></p></body></html>'''
+def _finding_rows(lifecycle: dict, status: str) -> str:
+    records = [r for r in lifecycle.get("records", []) if r.get("status") == status]
+    if not records:
+        return '<tr><td colspan="7" class="empty">None in this observation.</td></tr>'
+
+    rows: list[str] = []
+    for record in records:
+        rows.append(
+            "<tr>"
+            f"<td><strong>{escape(str(record.get('severity') or 'unknown').upper())}</strong></td>"
+            f"<td><code>{escape(str(record.get('finding_id') or 'unknown'))}</code></td>"
+            f"<td><code>{escape(str(record.get('subject_project') or 'unknown'))}</code></td>"
+            f"<td><code>{escape(str(record.get('dependency_project') or 'unknown'))}</code></td>"
+            f"<td>{escape(str(record.get('relationship_type') or 'unknown'))}</td>"
+            f"<td>{escape(str(record.get('change_type') or 'unknown'))}</td>"
+            f"<td>{escape(str(record.get('observation_count', 1)))}</td>"
+            "</tr>"
+        )
+    return "".join(rows)
+
+
+def html_report(portfolio: dict, changes: dict, impacts: dict, lifecycle: dict, external: dict) -> str:
+    summary = lifecycle.get("summary", {})
+    change_summary = changes.get("summary", {})
+    structural = (
+        int(change_summary.get("added", 0))
+        + int(change_summary.get("removed", 0))
+        + int(change_summary.get("changed", 0))
+    )
+    project_count = portfolio.get("project_count", len(portfolio.get("projects", [])))
+    activity = change_summary.get("activity_advanced", 0)
+    obligations = impacts.get("summary", {}).get("review_obligations", 0)
+    active = summary.get("active", 0)
+    resolved = summary.get("resolved", 0)
+    external_count = external.get("dependency_count", 0)
+    observation = portfolio.get("generated_at", "unknown")
+    assurance_boundary = lifecycle.get("assurance_boundary", "")
+
+    return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>UN/CEFACT Portfolio Assurance Report</title><style>
+:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}main{{max-width:1200px;margin:auto;padding:36px 22px 72px}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}h1{{margin:0 0 8px}}h2{{margin-top:32px}}.lede,.empty,.meta{{color:var(--muted)}}.note{{border-left:3px solid var(--accent);padding:11px 14px;background:var(--panel);margin:20px 0}}.stats{{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:20px 0 28px}}.stat{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px}}.stat strong{{display:block;font-size:24px}}.stat small{{display:block;color:var(--muted);margin-top:3px}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px;margin:16px 0 28px}}table{{width:100%;border-collapse:collapse;min-width:900px}}th,td{{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}code{{font-family:ui-monospace,SFMono-Regular,monospace;font-size:12px}}
+</style></head><body><main>
+<p><a href="index.html">← Portfolio</a> · <a href="findings.html">Current findings</a> · <a href="external-dependencies.html">External dependencies</a></p>
+<h1>UN/CEFACT Portfolio Assurance Report</h1>
+<p class="lede">Lifecycle-aware weekly view of observable portfolio evidence. This page is optimized for rapid inspection; the underlying evidence contracts and governance meaning are unchanged.</p>
+<div class="note"><strong>Observation:</strong> {escape(str(observation))}. Machine-readable lifecycle: <a href="findings-lifecycle.json">findings-lifecycle.json</a> · Markdown report: <a href="weekly-report.md">weekly-report.md</a>.</div>
+<div class="stats">
+<div class="stat"><span>Projects</span><strong>{escape(str(project_count))}</strong><small>Discovered</small></div>
+<div class="stat"><span>Structural changes</span><strong>{escape(str(structural))}</strong><small>Current observation</small></div>
+<div class="stat"><span>Activity advanced</span><strong>{escape(str(activity))}</strong><small>Activity-only</small></div>
+<div class="stat"><span>Review obligations</span><strong>{escape(str(obligations))}</strong><small>Direct</small></div>
+<div class="stat"><span>Active findings</span><strong>{escape(str(active))}</strong><small>Require disposition</small></div>
+<div class="stat"><span>Resolved retained</span><strong>{escape(str(resolved))}</strong><small>Lifecycle evidence</small></div>
+<div class="stat"><span>External dependencies</span><strong>{escape(str(external_count))}</strong><small>Declared context</small></div>
+</div>
+<h2>Active findings</h2>
+<p class="lede">Current policy-matched evidence conditions requiring tracked disposition.</p>
+<div class="table-wrap"><table><thead><tr><th>Severity</th><th>Finding</th><th>Reviewing project</th><th>Dependency</th><th>Relationship</th><th>Change</th><th>Observations</th></tr></thead><tbody>{_finding_rows(lifecycle, 'active')}</tbody></table></div>
+<h2>Resolved findings retained</h2>
+<p class="lede">Previously observed findings no longer active in the current observation, retained as lifecycle evidence.</p>
+<div class="table-wrap"><table><thead><tr><th>Severity</th><th>Finding</th><th>Reviewing project</th><th>Dependency</th><th>Relationship</th><th>Change</th><th>Observations</th></tr></thead><tbody>{_finding_rows(lifecycle, 'resolved')}</tbody></table></div>
+<h2>Interpretation boundary</h2>
+<div class="note">This report is generated from observable repository evidence, declared relationships, declared evidence policies, and declared external dependency context. Findings require tracked disposition but are not automatically compatibility failures, assurance failures, or trust decisions.</div>
+<p class="meta">{escape(str(assurance_boundary))}</p>
+</main></body></html>'''
 
 
 def main() -> int:
@@ -79,9 +148,13 @@ def main() -> int:
     external = _read(args.external, {"dependency_count": 0})
     md = markdown_report(portfolio, changes, impacts, lifecycle, external)
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    (args.output_dir / "findings-lifecycle.json").write_text(json.dumps(lifecycle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (args.output_dir / "findings-lifecycle.json").write_text(
+        json.dumps(lifecycle, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     (args.output_dir / "weekly-report.md").write_text(md, encoding="utf-8")
-    (args.output_dir / "weekly-report.html").write_text(html_report(md, lifecycle), encoding="utf-8")
+    (args.output_dir / "weekly-report.html").write_text(
+        html_report(portfolio, changes, impacts, lifecycle, external), encoding="utf-8"
+    )
     print(f"lifecycle: {lifecycle['summary']['active']} active, {lifecycle['summary']['resolved']} resolved")
     return 0
 

--- a/tests/test_weekly_report.py
+++ b/tests/test_weekly_report.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from build_lifecycle_report import html_report
+
+
+class WeeklyReportRenderingTests(unittest.TestCase):
+    def test_report_renders_summary_and_lifecycle_tables(self):
+        portfolio = {"generated_at": "2026-09-03T00:00:00Z", "project_count": 12}
+        changes = {"summary": {"added": 1, "removed": 1, "changed": 2, "activity_advanced": 3}}
+        impacts = {"summary": {"review_obligations": 4}}
+        lifecycle = {
+            "summary": {"active": 1, "resolved": 1},
+            "assurance_boundary": "Evidence is not a trust decision.",
+            "records": [
+                {
+                    "status": "active",
+                    "severity": "high",
+                    "finding_id": "PF-1",
+                    "subject_project": "profile",
+                    "dependency_project": "core",
+                    "relationship_type": "profile-of",
+                    "change_type": "changed",
+                    "observation_count": 2,
+                },
+                {
+                    "status": "resolved",
+                    "severity": "medium",
+                    "finding_id": "PF-2",
+                    "subject_project": "consumer",
+                    "dependency_project": "profile",
+                    "relationship_type": "depends-on",
+                    "change_type": "removed",
+                    "observation_count": 1,
+                },
+            ],
+        }
+        external = {"dependency_count": 5}
+
+        rendered = html_report(portfolio, changes, impacts, lifecycle, external)
+
+        self.assertIn("<table>", rendered)
+        self.assertEqual(rendered.count("<table>"), 2)
+        self.assertIn("Active findings", rendered)
+        self.assertIn("Resolved findings retained", rendered)
+        self.assertIn("<strong>4</strong><small>Current observation</small>", rendered)
+        self.assertIn("<strong>4</strong><small>Direct</small>", rendered)
+        self.assertIn("<code>PF-1</code>", rendered)
+        self.assertIn("<code>PF-2</code>", rendered)
+        self.assertIn("findings-lifecycle.json", rendered)
+        self.assertIn("weekly-report.md", rendered)
+        self.assertIn("Evidence is not a trust decision.", rendered)
+
+    def test_report_escapes_finding_evidence(self):
+        rendered = html_report(
+            {},
+            {"summary": {}},
+            {"summary": {}},
+            {
+                "summary": {"active": 1, "resolved": 0},
+                "records": [
+                    {
+                        "status": "active",
+                        "severity": "high<script>",
+                        "finding_id": "<unsafe>",
+                        "subject_project": "a&b",
+                        "dependency_project": "core",
+                    }
+                ],
+            },
+            {},
+        )
+
+        self.assertNotIn("<unsafe>", rendered)
+        self.assertIn("&lt;unsafe&gt;", rendered)
+        self.assertIn("a&amp;b", rendered)
+        self.assertNotIn("high<script>", rendered.lower())
+
+    def test_empty_sections_have_explicit_rows(self):
+        rendered = html_report({}, {"summary": {}}, {"summary": {}}, {"summary": {}, "records": []}, {})
+        self.assertEqual(rendered.count("None in this observation."), 2)
+        self.assertEqual(rendered.count('colspan="7"'), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #36.

## Proposed changes

- replace the weekly report's lossy Markdown-to-HTML presentation path with direct structured HTML rendering from the same evidence objects
- add compact summary cards for project/change/review/finding/dependency counts
- render active and resolved lifecycle findings as separate tables
- preserve links to raw lifecycle JSON and the Markdown report
- preserve the interpretation boundary and assurance semantics

## Evidence / testing

- adds `tests/test_weekly_report.py`
- verifies two lifecycle tables and stable headline counts
- verifies active/resolved evidence is rendered
- verifies empty lifecycle sections are explicit
- verifies untrusted evidence values are HTML-escaped

## Compatibility

No evidence contract, lifecycle semantics, Markdown report semantics, dependency, or GitHub Pages deployment mechanism changes. This is a presentation-layer change only.

## Judgment

A scan-friendly presentation must improve human inspectability without turning evidence counts or findings into an aggregate assurance score or trust decision.