### PR TITLE
Make findings readable and add activity trace links

### DIFF
--- a/scripts/build_findings.py
+++ b/scripts/build_findings.py
@@ -14,34 +14,65 @@ sys.path.insert(0, str(ROOT / "src"))
 from uncefact_portfolio_monitor.findings import derive_findings
 
 
+def _finding_card(item: dict) -> str:
+    severity = escape(str(item.get("severity") or "unknown")).upper()
+    title = escape(str(item.get("title") or "Finding"))
+    finding_id = escape(str(item.get("finding_id") or ""))
+    status = escape(str(item.get("status") or "open")).upper()
+    subject = escape(str(item.get("subject_project") or "unknown"))
+    dependency = escape(str(item.get("dependency_project") or "unknown"))
+    relationship = escape(str(item.get("relationship_type") or "unknown"))
+    change = escape(str(item.get("change_type") or "unknown"))
+    policy = escape(str(item.get("policy_id") or "unknown"))
+    reason = escape(str(item.get("reason") or "Review required by declared evidence policy."))
+    evidence = item.get("evidence") or {}
+    impact_ref = escape(str(evidence.get("impact_ref") or ""), quote=True)
+    change_evidence = escape(str(evidence.get("change_evidence") or ""))
+    relationship_provenance = escape(str(evidence.get("relationship_provenance") or ""))
+    policy_provenance = escape(str(evidence.get("policy_provenance") or ""))
+
+    plain = (
+        f"{subject} depends on {dependency} through the declared {relationship} relationship. "
+        f"The dependency recorded a {change} structural change in the current observation, so the dependent project requires tracked review."
+    )
+
+    evidence_bits = []
+    if impact_ref:
+        evidence_bits.append(f'<a href="{impact_ref}">Review obligation</a>')
+    if change_evidence:
+        evidence_bits.append(f"Change evidence: <code>{change_evidence}</code>")
+    if relationship_provenance:
+        evidence_bits.append(f"Relationship provenance: <code>{relationship_provenance}</code>")
+    if policy_provenance:
+        evidence_bits.append(f"Policy provenance: <code>{policy_provenance}</code>")
+
+    return f'''<article class="finding" id="{finding_id}">
+<div class="finding-head"><div><span class="severity">{severity}</span><h2>{title}</h2></div><span class="status">{status}</span></div>
+<p class="interpretation">{plain}</p>
+<p class="reason"><strong>Why this was flagged:</strong> {reason}</p>
+<dl><div><dt>Review project</dt><dd><code>{subject}</code></dd></div><div><dt>Changed dependency</dt><dd><code>{dependency}</code></dd></div><div><dt>Relationship</dt><dd>{relationship}</dd></div><div><dt>Change</dt><dd>{change}</dd></div><div><dt>Policy</dt><dd><code>{policy}</code></dd></div></dl>
+<p class="evidence"><strong>Evidence:</strong> {' · '.join(evidence_bits) if evidence_bits else 'See machine-readable finding evidence.'}</p>
+<p class="finding-id"><strong>Stable finding ID:</strong> <code>{finding_id}</code></p>
+</article>'''
+
+
 def render(data: dict) -> str:
-    rows = []
-    for item in data.get("findings", []):
-        rows.append(
-            "<tr>"
-            f"<td><code>{escape(item['finding_id'])}</code></td>"
-            f"<td>{escape(item['severity'])}</td>"
-            f"<td><code>{escape(item['subject_project'])}</code></td>"
-            f"<td><code>{escape(item['dependency_project'])}</code></td>"
-            f"<td>{escape(item['relationship_type'])}</td>"
-            f"<td>{escape(item['change_type'])}</td>"
-            f"<td><code>{escape(item['policy_id'])}</code></td>"
-            "</tr>"
-        )
-    if not rows:
-        rows.append('<tr><td colspan="7">No policy-matched findings in this observation.</td></tr>')
+    findings = data.get("findings", [])
+    cards = "".join(_finding_card(item) for item in findings)
+    if not cards:
+        cards = '<div class="empty">No policy-matched findings in this observation.</div>'
     summary = data.get("summary", {})
     by_severity = summary.get("by_severity", {})
     return f'''<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>UN/CEFACT Portfolio Findings</title>
-<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1250px;margin:auto;padding:36px 22px;color:#18202a}}a{{color:#155eef}}table{{width:100%;border-collapse:collapse;margin:24px 0}}th,td{{text-align:left;padding:10px;border-bottom:1px solid #ddd;vertical-align:top}}th{{font-size:12px;text-transform:uppercase}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.note{{border-left:3px solid #155eef;padding:10px 14px;background:#f5f7fa}}</style></head>
-<body><p><a href="index.html">← Portfolio</a> · <a href="relationships.html">Relationships</a> · <a href="impacts.html">Impact review</a></p><h1>Evidence-backed portfolio findings</h1>
-<p>Findings are deterministic matches between declared evidence policies and current review obligations. They require tracked disposition but are not automatically compatibility failures, assurance failures, or trust decisions.</p>
-<div class="note">{summary.get('open_findings',0)} open finding(s): {by_severity.get('critical',0)} critical, {by_severity.get('high',0)} high, {by_severity.get('medium',0)} medium, {by_severity.get('low',0)} low. Machine-readable evidence: <a href="findings.json">findings.json</a>.</div>
-<table><thead><tr><th>Finding</th><th>Severity</th><th>Review project</th><th>Changed dependency</th><th>Relationship</th><th>Change</th><th>Policy</th></tr></thead><tbody>{''.join(rows)}</tbody></table>
+<style>:root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}main{{max-width:1180px;margin:auto;padding:36px 22px 72px}}a{{color:var(--accent)}}.nav{{margin-bottom:24px}}.note,.finding{{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;margin:18px 0}}.note{{border-left:3px solid var(--accent)}}.finding-head{{display:flex;justify-content:space-between;gap:16px;align-items:flex-start}}h2{{margin:4px 0 0;font-size:21px}}.severity,.status{{font-size:12px;font-weight:700;letter-spacing:.05em}}.severity{{color:#9a3412}}.status{{background:#eef2ff;border-radius:999px;padding:4px 8px}}.interpretation{{font-size:16px}}.reason{{background:#f8fafc;padding:10px 12px;border-radius:8px}}dl{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;margin:16px 0}}dl div{{border-top:1px solid var(--line);padding-top:8px}}dt{{font-size:12px;text-transform:uppercase;color:var(--muted)}}dd{{margin:3px 0 0}}code{{font-family:ui-monospace,SFMono-Regular,monospace}}.evidence,.finding-id{{color:var(--muted)}}.finding-id{{font-size:13px}}.empty{{padding:20px;background:var(--panel);border:1px solid var(--line);border-radius:12px}}</style></head>
+<body><main><p class="nav"><a href="index.html">← Portfolio</a> · <a href="relationships.html">Relationships</a> · <a href="impacts.html">Impact review</a> · <a href="changes.html">Changes</a></p><h1>Evidence-backed portfolio findings</h1>
+<p>Each finding is presented first as a human-readable review condition. The alphanumeric finding ID is retained as stable secondary metadata for machine processing, cross-reference, and lifecycle tracking.</p>
+<div class="note"><strong>{summary.get('open_findings',0)} open finding(s)</strong>: {by_severity.get('critical',0)} critical, {by_severity.get('high',0)} high, {by_severity.get('medium',0)} medium, {by_severity.get('low',0)} low. Machine-readable evidence: <a href="findings.json">findings.json</a>.</div>
+{cards}
 <p><small>{escape(data.get('assurance_boundary',''))}</small></p>
-</body></html>'''
+</main></body></html>'''
 
 
 def main() -> int:

--- a/scripts/build_observation_horizons.py
+++ b/scripts/build_observation_horizons.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from html import escape
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -110,7 +111,19 @@ def build_evidence_index(changes: dict, impacts: dict, findings: dict) -> dict[s
     return index
 
 
-def _evidence_links(path: str, evidence_index: dict[str, set[str]]) -> str:
+def _commit_history_url(web_url: str) -> str:
+    base = (web_url or "").rstrip("/")
+    if not base:
+        return ""
+    host = urlparse(base).netloc.lower()
+    if host == "github.com" or host.endswith(".github.com"):
+        return base + "/commits"
+    if "gitlab" in host:
+        return base + "/-/commits"
+    return base
+
+
+def _evidence_links(path: str, web_url: str, evidence_index: dict[str, set[str]]) -> str:
     evidence = evidence_index.get(path, set())
     links = []
     for key, href, label in (
@@ -120,7 +133,13 @@ def _evidence_links(path: str, evidence_index: dict[str, set[str]]) -> str:
     ):
         if key in evidence:
             links.append(f'<a class="evidence-link" href="{href}">{label}</a>')
-    return " ".join(links) or '<span class="empty">No current-window evidence link</span>'
+    if links:
+        return " ".join(links)
+    activity_url = _commit_history_url(web_url)
+    if activity_url:
+        safe_url = escape(activity_url, quote=True)
+        return f'<span class="empty">No current-window finding or review.</span> <a class="activity-link" href="{safe_url}">Inspect recent commits ↗</a>'
+    return '<span class="empty">No current-window finding or review; repository activity link unavailable.</span>'
 
 
 def _project_rows(horizon: dict, evidence_index: dict[str, set[str]]) -> str:
@@ -129,12 +148,13 @@ def _project_rows(horizon: dict, evidence_index: dict[str, set[str]]) -> str:
         name = escape(project.get("name") or "Unnamed")
         path_raw = project.get("path_with_namespace") or "unknown"
         path = escape(path_raw)
-        url = escape(project.get("web_url") or "#", quote=True)
+        web_url_raw = project.get("web_url") or ""
+        url = escape(web_url_raw or "#", quote=True)
         activity = project.get("last_activity_at")
         rendered_activity = escape(_fmt(activity)) if activity else "Unknown"
         rows.append(
             f'<tr><td><a href="{url}">{name}</a><div class="path">{path}</div></td>'
-            f'<td>{rendered_activity}</td><td>{_evidence_links(path_raw, evidence_index)}</td></tr>'
+            f'<td>{rendered_activity}</td><td>{_evidence_links(path_raw, web_url_raw, evidence_index)}</td></tr>'
         )
     return "".join(rows) or '<tr><td colspan="3" class="empty">No project activity observed in this horizon.</td></tr>'
 
@@ -149,16 +169,16 @@ def render_horizons(data: dict, evidence_index: dict[str, set[str]] | None = Non
             f'''<section class="horizon" id="{horizon_id}"><div class="horizon-head"><div><h2>{escape(horizon.get('label') or '')}</h2>
 <p class="lede"><strong>{escape(_fmt(horizon.get('start')))} → {escape(_fmt(horizon.get('end')))}</strong></p></div>
 <a class="metric" href="#{horizon_id}-projects"><strong>{int(horizon.get('project_count', 0))}</strong><span>of {int(horizon.get('portfolio_project_count', 0))} projects ({share:.0f}%)</span><small>View observed projects ↓</small></a></div>
-<div class="table-wrap" id="{horizon_id}-projects"><table><thead><tr><th>Project</th><th>Last recorded activity</th><th>Current-window evidence</th></tr></thead><tbody>{_project_rows(horizon, evidence_index)}</tbody></table></div></section>'''
+<div class="table-wrap" id="{horizon_id}-projects"><table><thead><tr><th>Project</th><th>Last recorded activity</th><th>Evidence / activity trace</th></tr></thead><tbody>{_project_rows(horizon, evidence_index)}</tbody></table></div></section>'''
         )
     return f'''<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>UN/CEFACT Observation Horizons</title><style>
 :root{{--bg:#f7f8fa;--panel:#fff;--text:#18202a;--muted:#667085;--line:#dfe3e8;--accent:#155eef}}
-*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}main{{max-width:1180px;margin:auto;padding:36px 22px 72px}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}h1{{margin-bottom:8px}}h2{{margin:0 0 4px}}.lede,.empty{{color:var(--muted)}}.nav{{display:flex;gap:8px;flex-wrap:wrap;margin:0 0 24px}}.nav a,.evidence-link{{display:inline-block;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:6px 9px}}.note{{border-left:3px solid var(--accent);padding:12px 14px;background:var(--panel);margin:20px 0 28px}}.horizon{{margin:28px 0 40px;scroll-margin-top:16px}}.horizon-head{{display:flex;gap:18px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}}.metric{{display:block;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px;min-width:210px;color:var(--text)}}.metric:hover{{border-color:var(--accent);text-decoration:none}}.metric strong,.metric span,.metric small{{display:block}}.metric strong{{font-size:28px}}.metric span,.metric small{{color:var(--muted)}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px;margin-top:14px;scroll-margin-top:16px}}table{{width:100%;border-collapse:collapse;min-width:820px}}th,td{{text-align:left;padding:12px 14px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}.path{{font-size:12px;color:var(--muted);margin-top:3px}}.evidence-link{{margin:0 5px 5px 0;padding:4px 7px;font-size:13px}}
+*{{box-sizing:border-box}}body{{margin:0;background:var(--bg);color:var(--text);font:15px/1.55 system-ui,-apple-system,Segoe UI,sans-serif}}main{{max-width:1180px;margin:auto;padding:36px 22px 72px}}a{{color:var(--accent);text-decoration:none}}a:hover{{text-decoration:underline}}h1{{margin-bottom:8px}}h2{{margin:0 0 4px}}.lede,.empty{{color:var(--muted)}}.nav{{display:flex;gap:8px;flex-wrap:wrap;margin:0 0 24px}}.nav a,.evidence-link,.activity-link{{display:inline-block;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:6px 9px}}.note{{border-left:3px solid var(--accent);padding:12px 14px;background:var(--panel);margin:20px 0 28px}}.horizon{{margin:28px 0 40px;scroll-margin-top:16px}}.horizon-head{{display:flex;gap:18px;align-items:flex-start;justify-content:space-between;flex-wrap:wrap}}.metric{{display:block;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px;min-width:210px;color:var(--text)}}.metric:hover{{border-color:var(--accent);text-decoration:none}}.metric strong,.metric span,.metric small{{display:block}}.metric strong{{font-size:28px}}.metric span,.metric small{{color:var(--muted)}}.table-wrap{{overflow:auto;background:var(--panel);border:1px solid var(--line);border-radius:12px;margin-top:14px;scroll-margin-top:16px}}table{{width:100%;border-collapse:collapse;min-width:820px}}th,td{{text-align:left;padding:12px 14px;border-bottom:1px solid var(--line);vertical-align:top}}th{{font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}}tr:last-child td{{border-bottom:0}}.path{{font-size:12px;color:var(--muted);margin-top:3px}}.evidence-link,.activity-link{{margin:0 5px 5px 0;padding:4px 7px;font-size:13px}}.activity-link{{margin-left:6px}}
 </style></head><body><main>
 <nav class="nav" aria-label="Evidence navigation"><a href="index.html">Portfolio</a><a href="changes.html">Changes</a><a href="impacts.html">Impact review</a><a href="findings.html">Findings</a><a href="observation-horizons.json">Raw horizon JSON</a></nav>
 <h1>Observation horizons</h1><p class="lede">Broader activity context for a slow-moving standards portfolio, anchored to the same observation timestamp as the monitor.</p>
-<div class="note"><strong>Interpretation boundary:</strong> {escape(data.get('interpretation') or '')} Evidence links in project rows refer to the <strong>current snapshot-to-snapshot window</strong>; their presence does not mean the broader-horizon activity caused that finding or review obligation.</div>{''.join(sections)}
+<div class="note"><strong>Interpretation boundary:</strong> {escape(data.get('interpretation') or '')} Current-window links point to findings, review obligations, or change evidence from the latest snapshot comparison. Where none exists, the commit-history link is only an <strong>activity trace</strong>; it does not mean a commit was normative, material, or causally related to a finding.</div>{''.join(sections)}
 </main></body></html>'''
 
 
@@ -210,7 +230,7 @@ def main() -> int:
     )
     index_html = args.index.read_text(encoding="utf-8")
     args.index.write_text(inject_homepage(index_html, homepage_fragment(data)), encoding="utf-8")
-    print("built month-to-observed-date and trailing-90-day observation horizons with evidence links")
+    print("built month-to-observed-date and trailing-90-day observation horizons with evidence and activity links")
     return 0
 
 

--- a/tests/test_findings_render.py
+++ b/tests/test_findings_render.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "build_findings", ROOT / "scripts" / "build_findings.py"
+)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(module)
+
+
+class FindingsRenderTests(unittest.TestCase):
+    def test_finding_is_human_readable_before_machine_id(self):
+        data = {
+            "summary": {
+                "open_findings": 1,
+                "by_severity": {"critical": 0, "high": 1, "medium": 0, "low": 0},
+            },
+            "findings": [{
+                "finding_id": "UCF-PF-001-F3EB6692AE1A",
+                "status": "open",
+                "severity": "high",
+                "title": "Trust infrastructure dependency changed",
+                "policy_id": "UCF-PF-001",
+                "subject_project": "un/unece/uncefact/reviewer",
+                "dependency_project": "un/unece/uncefact/dependency",
+                "relationship_type": "trust-infrastructure-dependency",
+                "change_type": "changed",
+                "reason": "A project with a declared trust-infrastructure dependency requires tracked disposition after structural change in that dependency.",
+                "evidence": {
+                    "impact_ref": "impacts.json#/review_obligations/0",
+                    "change_evidence": "changes.json#/changed/0",
+                    "relationship_provenance": "relationships.json#/relationships/0",
+                    "policy_provenance": "declared-policy",
+                },
+            }],
+            "assurance_boundary": "A finding is not by itself a trust decision.",
+        }
+        html = module.render(data)
+        self.assertIn("Trust infrastructure dependency changed", html)
+        self.assertIn("Why this was flagged", html)
+        self.assertIn("requires tracked disposition", html)
+        self.assertIn("Stable finding ID", html)
+        self.assertIn("UCF-PF-001-F3EB6692AE1A", html)
+        self.assertIn("Review obligation", html)
+        self.assertIn("Change evidence", html)
+        self.assertIn("Relationship provenance", html)
+        self.assertLess(
+            html.index("Trust infrastructure dependency changed"),
+            html.index("Stable finding ID"),
+        )
+
+    def test_render_escapes_finding_content(self):
+        data = {
+            "summary": {"open_findings": 1, "by_severity": {}},
+            "findings": [{
+                "finding_id": "UCF-PF-X",
+                "status": "open",
+                "severity": "high",
+                "title": "<script>alert(1)</script>",
+                "policy_id": "UCF-PF-001",
+                "subject_project": "subject",
+                "dependency_project": "dependency",
+                "relationship_type": "depends-on",
+                "change_type": "changed",
+                "reason": "review",
+                "evidence": {},
+            }],
+            "assurance_boundary": "",
+        }
+        html = module.render(data)
+        self.assertNotIn("<script>alert(1)</script>", html)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_observation_horizons.py
+++ b/tests/test_observation_horizons.py
@@ -19,13 +19,13 @@ class ObservationHorizonTests(unittest.TestCase):
                 {
                     "name": "September project",
                     "path_with_namespace": "un/unece/uncefact/september",
-                    "web_url": "https://example.test/september",
+                    "web_url": "https://github.com/example/september",
                     "last_activity_at": "2026-09-02T12:00:00Z",
                 },
                 {
                     "name": "August project",
                     "path_with_namespace": "un/unece/uncefact/august",
-                    "web_url": "https://example.test/august",
+                    "web_url": "https://gitlab.example.org/un/august",
                     "last_activity_at": "2026-08-20T12:00:00Z",
                 },
                 {
@@ -76,6 +76,20 @@ class ObservationHorizonTests(unittest.TestCase):
         self.assertEqual(index["un/unece/uncefact/dependency"], {"impacts"})
         self.assertEqual(index["un/unece/uncefact/reviewer"], {"findings"})
 
+    def test_commit_history_urls_follow_repository_host(self):
+        self.assertEqual(
+            module._commit_history_url("https://github.com/example/project"),
+            "https://github.com/example/project/commits",
+        )
+        self.assertEqual(
+            module._commit_history_url("https://gitlab.example.org/group/project"),
+            "https://gitlab.example.org/group/project/-/commits",
+        )
+        self.assertEqual(
+            module._commit_history_url("https://example.test/project"),
+            "https://example.test/project",
+        )
+
     def test_render_links_project_to_supported_current_window_evidence(self):
         data = module.build_horizons(self.snapshot())
         # August remains in the broad horizon but deliberately has no current-window evidence.
@@ -86,8 +100,10 @@ class ObservationHorizonTests(unittest.TestCase):
         self.assertIn('href="changes.html"', html)
         self.assertIn('href="impacts.html"', html)
         self.assertIn('href="findings.html"', html)
-        self.assertIn("No current-window evidence link", html)
-        self.assertIn("does not mean the broader-horizon activity caused", html)
+        self.assertIn("No current-window finding or review.", html)
+        self.assertIn("Inspect recent commits", html)
+        self.assertIn("https://gitlab.example.org/un/august/-/commits", html)
+        self.assertIn("commit-history link is only an", html)
         self.assertIn('href="#month-to-observed-date-projects"', html)
 
     def test_render_escapes_project_content_and_explains_boundary(self):


### PR DESCRIPTION
Closes #42.

This PR makes the Findings page a human-readable judgment surface instead of leading with opaque machine identifiers. Findings now lead with severity, title, plain-English interpretation, reason for flagging, review/dependency context, policy, evidence/provenance, and retain the deterministic finding ID only as stable secondary metadata.

It also improves observation-horizon traceability. Rows with no current-window finding/review evidence now provide a repository activity trace via the repository's commit-history surface where the host is recognizable (GitHub/GitLab). The UI explicitly distinguishes this from current-window evidence and states that commit activity is not necessarily normative, material, or causally related to a finding.

Regression tests cover human-readable finding rendering, HTML escaping, GitHub/GitLab commit-history URL construction, and the no-current-window-evidence activity trace case.