### PR TITLE
chore(governance): close public repository baseline gaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/monitor-gap.md
+++ b/.github/ISSUE_TEMPLATE/monitor-gap.md
@@ -1,0 +1,17 @@
+---
+name: Monitor gap
+description: Report a reproducible collection, evidence, state, classification or publication gap
+title: ""
+labels: []
+assignees: []
+---
+
+## Problem / proposition
+
+## Evidence window and authoritative upstream source
+
+## Reproduction / evidence
+
+## Expected outcome / acceptance criteria
+
+## Retained-state, compatibility or evidence impact

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns: ["*"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Change / proposition
+
+## Authority and evidence window
+
+- Monitor-owned surface affected:
+- Upstream authority deliberately not changed:
+- Evidence window/source revisions:
+
+## Validation
+
+- [ ] applicable tests/checks pass
+- [ ] regression/negative cases are covered where consequential
+- [ ] missing upstream evidence is not represented as PASS
+- [ ] generated reports/docs remain aligned
+
+## Compatibility / residual risk
+
+Record state migration, evidence invalidation, downstream impact, or remaining uncertainty.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+Participation requires professional, respectful, good-faith collaboration. Technical and governance disagreement is expected; critique should address claims, evidence, implementation and consequences rather than individuals. Harassment, discrimination, threats and deliberate intimidation are not acceptable.
+
+Maintainers may remove content or restrict participation when behaviour materially undermines a safe and productive project environment. Serious concerns should be raised privately with the repository maintainer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+For substantive changes, preserve an Issue → PR → tests/evidence → merge trail. State the monitor proposition or defect, evidence window, affected authority boundary and acceptance criteria; implement the smallest coherent change; add regression/negative tests for consequential behaviour; and merge only after applicable validation passes.
+
+Do not infer upstream decisions from missing evidence, inactivity, or workflow state. Derived observations must remain traceable to authoritative upstream sources.
+
+Security reports must follow [`SECURITY.md`](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Security fixes are applied to current `main` and the latest supported release. Do not open public issues for undisclosed vulnerabilities. Use GitHub private vulnerability reporting when available, or contact the maintainer through a private channel identified on the maintainer profile.
+
+Include affected revision/version, reproduction steps, impact, affected retained/generated evidence, and any known mitigation.
+
+This monitor observes external UN/CEFACT repositories and produces derived situational-awareness evidence. A collection, state, classification, or publication defect can invalidate prior observations; remediation must identify affected evidence and must not turn missing/indeterminate upstream evidence into PASS. UN/CEFACT repositories remain authoritative for their own state and decisions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,7 @@
+# Support
+
+Use GitHub Issues for reproducible collection, classification, retained-state, report or documentation defects and bounded feature proposals. Include the affected revision/evidence window, expected and observed behaviour, and the smallest useful evidence reference.
+
+Security vulnerabilities must follow [`SECURITY.md`](SECURITY.md).
+
+This repository owns monitor logic and derived reports; upstream UN/CEFACT repositories remain authoritative for their own project state and decisions.

--- a/docs/public-repository-baseline.md
+++ b/docs/public-repository-baseline.md
@@ -1,0 +1,18 @@
+# Public repository baseline
+
+This record captures controls reviewed under issue #35. It is repository assurance evidence, not external certification.
+
+| Control | State | Evidence | Residual risk |
+|---|---|---|---|
+| Purpose/adoption/authority boundary | PASS | `README.md`, `docs/`, config/release surfaces | Upstream UN/CEFACT repositories remain authoritative. |
+| Licensing | EVIDENCE REQUIRED | no top-level license or explicit repository licensing statement located in reviewed source | License selection is a human authority decision; tracked separately. |
+| Security reporting | PASS | `SECURITY.md` | Hosted private-reporting enablement remains platform evidence. |
+| Contribution/community/support | PASS | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, issue/PR templates | None identified. |
+| Dependency updates | PASS | `.github/dependabot.yml` | Hosted Dependabot enablement remains platform evidence. |
+| Default-branch protection | EVIDENCE REQUIRED | rulesets API returned no active ruleset on 2026-09-05 | Tracked separately as a repository-setting control. |
+| Tests/evidence/publication | PASS / bounded | `tests/`, workflows, generated reports/releases | Workflow green is not upstream decision evidence. |
+| Authority boundary | PASS | README/docs methodology | Missing/inactive upstream evidence must not be interpreted as a decision or PASS. |
+
+## Completion boundary
+
+Repository-owned baseline gaps are closed by the remediation PR. Licensing and default-branch protection remain explicit bounded residuals because they require human/platform authority rather than code-only inference.


### PR DESCRIPTION
Closes #35 repository-owned baseline gaps.

## Proposed changes
- add security, support, contribution and conduct policies;
- add issue/PR templates;
- add grouped GitHub Actions/Python Dependabot coverage;
- record a final baseline evidence matrix.

## Existing controls verified
The monitor already has substantive README/docs, config, tests, release and publication machinery.

## Residual judgments
- no active ruleset was observed through the GitHub rulesets API;
- no explicit repository license was located in the reviewed source.

These are split to dedicated governance issues rather than guessed or represented as PASS.

## Authority boundary
This monitor owns derived observation/reporting logic; UN/CEFACT repositories retain authority over their own state and decisions.

```yaml
change:
  type: chore
  scope: governance
  breaking: false
  authority_impact: none
  assurance_impact: high
```
