### PR TITLE
docs(licensing): declare Apache-2.0 repository license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2026 the UN/CEFACT Portfolio Monitor contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ Future evidence providers may add role-aware repository checks, semantic/schema 
 - **v1.0.0 — Alaknanda** — stable evidence contract and operational release baseline.
 
 Release codenames are randomly selected from the configured pool derived from Wikipedia's `Category:Tributaries of the Ganges` and are permanently recorded in release manifests.
+
+## License
+
+Repository-authored code, documentation, configuration, and generated monitor outputs are licensed under the [Apache License 2.0](LICENSE).
+
+Material observed, quoted, linked, or retrieved from UN/CEFACT repositories and other external sources is **not relicensed by this repository**. Such material remains subject to the terms, notices, and authority of its original source.

--- a/docs/public-repository-baseline.md
+++ b/docs/public-repository-baseline.md
@@ -5,7 +5,7 @@ This record captures controls reviewed under issue #35. It is repository assuran
 | Control | State | Evidence | Residual risk |
 |---|---|---|---|
 | Purpose/adoption/authority boundary | PASS | `README.md`, `docs/`, config/release surfaces | Upstream UN/CEFACT repositories remain authoritative. |
-| Licensing | EVIDENCE REQUIRED | no top-level license or explicit repository licensing statement located in reviewed source | License selection is a human authority decision; tracked separately. |
+| Licensing | PASS | top-level `LICENSE` (Apache-2.0) and README licensing boundary | Externally sourced UN/CEFACT and other third-party material is explicitly excluded from relicensing and remains subject to source terms. |
 | Security reporting | PASS | `SECURITY.md` | Hosted private-reporting enablement remains platform evidence. |
 | Contribution/community/support | PASS | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, issue/PR templates | None identified. |
 | Dependency updates | PASS | `.github/dependabot.yml` | Hosted Dependabot enablement remains platform evidence. |
@@ -15,4 +15,4 @@ This record captures controls reviewed under issue #35. It is repository assuran
 
 ## Completion boundary
 
-Repository-owned baseline gaps are closed by the remediation PR. Licensing and default-branch protection remain explicit bounded residuals because they require human/platform authority rather than code-only inference.
+Repository-owned baseline and licensing gaps are closed through governed PRs. Default-branch protection remains an explicit bounded residual because it requires GitHub repository-administration authority rather than code-only inference.


### PR DESCRIPTION
Closes #46.

## Proposed changes
- add a top-level Apache-2.0 `LICENSE` for repository-authored code, documentation, configuration, and generated monitor outputs;
- state explicitly that observed/quoted/retrieved UN/CEFACT and other third-party material is not relicensed;
- update the public-repository baseline licensing control from `EVIDENCE REQUIRED` to `PASS`.

## Authority boundary
This repository licenses only material it owns. Upstream UN/CEFACT repositories and other external sources retain their own licensing and normative authority.

## Validation
Merge only after the repository's existing validation/Pages checks pass.

```yaml
change:
  type: docs
  scope: licensing
  breaking: false
  authority_impact: material
  assurance_impact: medium
```
